### PR TITLE
TIM-675: add TypeBuilder primitive rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky && effect-language-service patch",
     "check": "oxlint -c .oxlintrc.json --fix && pnpm tsgo --noEmit",
     "build": "tsdown",
-    "test": "vitest",
+    "test": "vitest run",
     "prepublishOnly": "pnpm build"
   },
   "files": [
@@ -27,6 +27,9 @@
     "url": "https://github.com/tim-smart/clanka.git"
   },
   "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48",
+  "dependencies": {
+    "typescript": "^5.9.3"
+  },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
@@ -42,7 +45,6 @@
     "oxlint": "^1.49.0",
     "prettier": "^3.8.1",
     "tsdown": "^0.20.3",
-    "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.5.2
@@ -50,9 +54,6 @@ importers:
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260219.1)(typescript@5.9.3)
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.3.5)(yaml@2.8.2)

--- a/src/TypeBuilder.test.ts
+++ b/src/TypeBuilder.test.ts
@@ -24,6 +24,7 @@ const literalCases = [
   ["number literals", Schema.Literal(42), "42"],
   ["boolean literals", Schema.Literal(true), "true"],
   ["bigint literals", Schema.Literal(42n), "42n"],
+  ["negative zero literals", Schema.Literal(-0), "-0"],
   ["negative number literals", Schema.Literal(-42), "-42"],
   ["negative bigint literals", Schema.Literal(-42n), "-42n"],
 ] as const satisfies ReadonlyArray<

--- a/src/TypeBuilder.test.ts
+++ b/src/TypeBuilder.test.ts
@@ -1,0 +1,57 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "vitest"
+import * as TypeBuilder from "./TypeBuilder.ts"
+
+const primitiveCases = [
+  ["string", Schema.String, "string"],
+  ["number", Schema.Number, "number"],
+  ["boolean", Schema.Boolean, "boolean"],
+  ["bigint", Schema.BigInt, "bigint"],
+  ["symbol", Schema.Symbol, "symbol"],
+  ["any", Schema.Any, "any"],
+  ["unknown", Schema.Unknown, "unknown"],
+  ["void", Schema.Void, "void"],
+  ["never", Schema.Never, "never"],
+  ["undefined", Schema.Undefined, "undefined"],
+  ["null", Schema.Null, "null"],
+  ["object", Schema.ObjectKeyword, "object"],
+] as const satisfies ReadonlyArray<
+  readonly [name: string, schema: Schema.Top, expected: string]
+>
+
+const literalCases = [
+  ["string literals", Schema.Literal("hello"), '"hello"'],
+  ["number literals", Schema.Literal(42), "42"],
+  ["boolean literals", Schema.Literal(true), "true"],
+  ["bigint literals", Schema.Literal(42n), "42n"],
+  ["negative number literals", Schema.Literal(-42), "-42"],
+  ["negative bigint literals", Schema.Literal(-42n), "-42n"],
+] as const satisfies ReadonlyArray<
+  readonly [name: string, schema: Schema.Top, expected: string]
+>
+
+describe("TypeBuilder", () => {
+  for (const [name, schema, expected] of primitiveCases) {
+    it(`renders ${name}`, () => {
+      expect(TypeBuilder.render(schema)).toBe(expected)
+    })
+  }
+
+  for (const [name, schema, expected] of literalCases) {
+    it(`renders ${name}`, () => {
+      expect(TypeBuilder.render(schema)).toBe(expected)
+    })
+  }
+
+  it("renders described unique symbols", () => {
+    expect(TypeBuilder.render(Schema.UniqueSymbol(Symbol("token")))).toBe(
+      'typeof Symbol.for("token")',
+    )
+  })
+
+  it("renders anonymous unique symbols", () => {
+    expect(TypeBuilder.render(Schema.UniqueSymbol(Symbol()))).toBe(
+      "unique symbol",
+    )
+  })
+})

--- a/src/TypeBuilder.ts
+++ b/src/TypeBuilder.ts
@@ -12,7 +12,7 @@ const nullTypeNode = (): ts.LiteralTypeNode =>
   ts.factory.createLiteralTypeNode(ts.factory.createNull())
 
 const numberLiteralTypeNode = (value: number): ts.LiteralTypeNode => {
-  if (value < 0) {
+  if (Object.is(value, -0) || value < 0) {
     return ts.factory.createLiteralTypeNode(
       ts.factory.createPrefixUnaryExpression(
         ts.SyntaxKind.MinusToken,

--- a/src/TypeBuilder.ts
+++ b/src/TypeBuilder.ts
@@ -1,0 +1,130 @@
+import { Schema, SchemaAST as AST } from "effect"
+import * as ts from "typescript"
+
+const unknownTypeNode = (): ts.KeywordTypeNode =>
+  ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword)
+
+const primitiveTypeNode = (
+  kind: ts.KeywordTypeSyntaxKind,
+): ts.KeywordTypeNode => ts.factory.createKeywordTypeNode(kind)
+
+const nullTypeNode = (): ts.LiteralTypeNode =>
+  ts.factory.createLiteralTypeNode(ts.factory.createNull())
+
+const numberLiteralTypeNode = (value: number): ts.LiteralTypeNode => {
+  if (value < 0) {
+    return ts.factory.createLiteralTypeNode(
+      ts.factory.createPrefixUnaryExpression(
+        ts.SyntaxKind.MinusToken,
+        ts.factory.createNumericLiteral(-value),
+      ),
+    )
+  }
+
+  return ts.factory.createLiteralTypeNode(
+    ts.factory.createNumericLiteral(value),
+  )
+}
+
+const bigintLiteralTypeNode = (value: bigint): ts.LiteralTypeNode => {
+  if (value < 0n) {
+    return ts.factory.createLiteralTypeNode(
+      ts.factory.createPrefixUnaryExpression(
+        ts.SyntaxKind.MinusToken,
+        ts.factory.createBigIntLiteral(`${-value}n`),
+      ),
+    )
+  }
+
+  return ts.factory.createLiteralTypeNode(
+    ts.factory.createBigIntLiteral(`${value}n`),
+  )
+}
+
+const literalTypeNode = (ast: AST.Literal): ts.LiteralTypeNode => {
+  switch (typeof ast.literal) {
+    case "string":
+      return ts.factory.createLiteralTypeNode(
+        ts.factory.createStringLiteral(ast.literal),
+      )
+    case "number":
+      return numberLiteralTypeNode(ast.literal)
+    case "boolean":
+      return ts.factory.createLiteralTypeNode(
+        ast.literal ? ts.factory.createTrue() : ts.factory.createFalse(),
+      )
+    case "bigint":
+      return bigintLiteralTypeNode(ast.literal)
+  }
+}
+
+const uniqueSymbolTypeNode = (ast: AST.UniqueSymbol): ts.TypeNode => {
+  const description = ast.symbol.description
+
+  if (description === undefined) {
+    return ts.factory.createTypeOperatorNode(
+      ts.SyntaxKind.UniqueKeyword,
+      primitiveTypeNode(ts.SyntaxKind.SymbolKeyword),
+    )
+  }
+
+  return ts.factory.createTypeQueryNode(
+    ts.factory.createIdentifier(`Symbol.for(${JSON.stringify(description)})`),
+  )
+}
+
+const toTypeNode = (ast: AST.AST): ts.TypeNode => {
+  switch (ast._tag) {
+    case "String":
+      return primitiveTypeNode(ts.SyntaxKind.StringKeyword)
+    case "Number":
+      return primitiveTypeNode(ts.SyntaxKind.NumberKeyword)
+    case "Boolean":
+      return primitiveTypeNode(ts.SyntaxKind.BooleanKeyword)
+    case "BigInt":
+      return primitiveTypeNode(ts.SyntaxKind.BigIntKeyword)
+    case "Symbol":
+      return primitiveTypeNode(ts.SyntaxKind.SymbolKeyword)
+    case "Any":
+      return primitiveTypeNode(ts.SyntaxKind.AnyKeyword)
+    case "Unknown":
+      return unknownTypeNode()
+    case "Void":
+      return primitiveTypeNode(ts.SyntaxKind.VoidKeyword)
+    case "Never":
+      return primitiveTypeNode(ts.SyntaxKind.NeverKeyword)
+    case "Undefined":
+      return primitiveTypeNode(ts.SyntaxKind.UndefinedKeyword)
+    case "Null":
+      return nullTypeNode()
+    case "ObjectKeyword":
+      return primitiveTypeNode(ts.SyntaxKind.ObjectKeyword)
+    case "Literal":
+      return literalTypeNode(ast)
+    case "UniqueSymbol":
+      return uniqueSymbolTypeNode(ast)
+    default:
+      return unknownTypeNode()
+  }
+}
+
+export const printNode = (
+  node: ts.Node,
+  options?: ts.PrinterOptions,
+): string => {
+  const sourceFile = ts.createSourceFile(
+    "print.ts",
+    "",
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS,
+  )
+  const printer = ts.createPrinter(options)
+
+  return printer.printNode(ts.EmitHint.Unspecified, node, sourceFile)
+}
+
+export const render = (
+  schema: Schema.Top,
+  options?: ts.PrinterOptions,
+): string => printNode(toTypeNode(AST.toType(schema.ast)), options)


### PR DESCRIPTION
## Summary
- add `src/TypeBuilder.ts` with decoded-side schema rendering for primitive, literal, and `UniqueSymbol` AST nodes plus printer helpers and an `unknown` fallback
- move `typescript` into runtime dependencies, keep the Vitest setup aligned with the spec, and update the test script to run once in CI-friendly mode
- add primitive and literal coverage in `src/TypeBuilder.test.ts`, including negative numeric literals and described/anonymous unique symbols

## Verification
- `pnpm install`
- `pnpm check`
- `pnpm test`