### PR TITLE
TIM-680 Restore build entrypoints for tsdown output

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
   "bin": {
     "lalph": "./dist/cli.mjs"
   },
+  "main": "./dist/index.mjs",
+  "exports": {
+    ".": "./dist/index.mjs",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "prepare": "husky && effect-language-service patch",
     "check": "oxlint -c .oxlintrc.json --fix && pnpm tsgo --noEmit",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { Effect } from "effect"
+import { program } from "./index.ts"
+
+const main = Effect.gen(function* () {
+  const message = yield* program
+  yield* Effect.sync(() => {
+    console.log(message)
+  })
+})
+
+await Effect.runPromise(main).catch((error) => {
+  console.error(error)
+  throw error
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export { program } from "./Example.ts"

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown"
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/cli.ts"],
+  outDir: "dist",
+  treeshake: true,
+  inlineOnly: false,
+})


### PR DESCRIPTION
## Summary
- add explicit `tsdown` entrypoints for a library bundle and CLI bundle so `pnpm build` emits `dist/index.mjs` and `dist/cli.mjs`
- add `src/index.ts` and a minimal `src/cli.ts` wrapper around the template program, keeping the CLI compatible with the current TypeScript config
- align `package.json` package entry metadata with the generated dist output and verify `pnpm check && pnpm test && pnpm build`