### PR TITLE
TIM-677 add object and record type rendering

### DIFF
--- a/src/TypeBuilder.test.ts
+++ b/src/TypeBuilder.test.ts
@@ -2,6 +2,8 @@ import { Schema } from "effect"
 import { describe, expect, it } from "vitest"
 import * as TypeBuilder from "./TypeBuilder.ts"
 
+const lines = (...parts: ReadonlyArray<string>): string => parts.join("\n")
+
 const primitiveCases = [
   ["string", Schema.String, "string"],
   ["number", Schema.Number, "number"],
@@ -53,6 +55,96 @@ describe("TypeBuilder", () => {
   it("renders anonymous unique symbols", () => {
     expect(TypeBuilder.render(Schema.UniqueSymbol(Symbol()))).toBe(
       "unique symbol",
+    )
+  })
+
+  it("renders structs", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.Struct({
+          name: Schema.String,
+          age: Schema.Number,
+        }),
+      ),
+    ).toBe(
+      lines(
+        "{",
+        "    readonly name: string;",
+        "    readonly age: number;",
+        "}",
+      ),
+    )
+  })
+
+  it("renders optional properties", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.Struct({
+          nickname: Schema.optionalKey(Schema.String),
+        }),
+      ),
+    ).toBe(lines("{", "    readonly nickname?: string;", "}"))
+  })
+
+  it("renders mutable properties", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.Struct({
+          count: Schema.mutableKey(Schema.Number),
+        }),
+      ),
+    ).toBe(lines("{", "    count: number;", "}"))
+  })
+
+  it("renders symbol property keys", () => {
+    const token = Symbol("token")
+
+    expect(
+      TypeBuilder.render(
+        Schema.Struct({
+          [token]: Schema.String,
+        }),
+      ),
+    ).toBe(lines("{", '    readonly [Symbol.for("token")]: string;', "}"))
+  })
+
+  it("renders records", () => {
+    expect(
+      TypeBuilder.render(Schema.Record(Schema.String, Schema.Number)),
+    ).toBe(lines("{", "    [x: string]: number;", "}"))
+  })
+
+  it("renders structs with rest records", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.StructWithRest(Schema.Struct({ name: Schema.String }), [
+          Schema.Record(Schema.String, Schema.Boolean),
+        ]),
+      ),
+    ).toBe(
+      lines(
+        "{",
+        "    readonly name: string;",
+        "    [x: string]: boolean;",
+        "}",
+      ),
+    )
+  })
+
+  it("renders documented fields", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.Struct({
+          token: Schema.String.annotate({ documentation: "Primary token" }),
+        }),
+      ),
+    ).toBe(
+      lines(
+        "{",
+        "    /** Primary token */",
+        "    readonly token: string;",
+        "}",
+      ),
     )
   })
 })

--- a/src/TypeBuilder.ts
+++ b/src/TypeBuilder.ts
@@ -1,6 +1,9 @@
 import { Schema, SchemaAST as AST } from "effect"
 import * as ts from "typescript"
 
+const resolveDocumentation = AST.resolveAt<string>("documentation")
+const identifierPattern = /^[$A-Z_a-z][$0-9A-Z_a-z]*$/u
+
 const unknownTypeNode = (): ts.KeywordTypeNode =>
   ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword)
 
@@ -73,6 +76,107 @@ const uniqueSymbolTypeNode = (ast: AST.UniqueSymbol): ts.TypeNode => {
   )
 }
 
+const symbolExpression = (symbol: symbol): ts.Expression => {
+  const description = symbol.description
+
+  if (description === undefined) {
+    return ts.factory.createCallExpression(
+      ts.factory.createIdentifier("Symbol"),
+      undefined,
+      [],
+    )
+  }
+
+  return ts.factory.createCallExpression(
+    ts.factory.createPropertyAccessExpression(
+      ts.factory.createIdentifier("Symbol"),
+      "for",
+    ),
+    undefined,
+    [ts.factory.createStringLiteral(description)],
+  )
+}
+
+const propertyName = (name: PropertyKey): ts.PropertyName => {
+  switch (typeof name) {
+    case "string":
+      return identifierPattern.test(name)
+        ? ts.factory.createIdentifier(name)
+        : ts.factory.createStringLiteral(name)
+    case "number":
+      return ts.factory.createNumericLiteral(name)
+    case "symbol":
+      return ts.factory.createComputedPropertyName(symbolExpression(name))
+  }
+}
+
+const jsDocText = (documentation: string): string => {
+  const lines = documentation.replaceAll("*/", "*\\/").split(/\r?\n/u)
+
+  return lines.length === 1
+    ? `* ${lines[0]} `
+    : `*\n * ${lines.join("\n * ")}\n `
+}
+
+const withJsDoc = <T extends ts.Node>(
+  node: T,
+  documentation: string | undefined,
+): T => {
+  if (documentation === undefined) {
+    return node
+  }
+
+  ts.addSyntheticLeadingComment(
+    node,
+    ts.SyntaxKind.MultiLineCommentTrivia,
+    jsDocText(documentation),
+    true,
+  )
+
+  return node
+}
+
+const propertySignatureTypeElement = (
+  propertySignature: AST.PropertySignature,
+): ts.PropertySignature =>
+  withJsDoc(
+    ts.factory.createPropertySignature(
+      propertySignature.type.context?.isMutable === true
+        ? undefined
+        : [ts.factory.createModifier(ts.SyntaxKind.ReadonlyKeyword)],
+      propertyName(propertySignature.name),
+      AST.isOptional(propertySignature.type)
+        ? ts.factory.createToken(ts.SyntaxKind.QuestionToken)
+        : undefined,
+      toTypeNode(propertySignature.type),
+    ),
+    resolveDocumentation(propertySignature.type),
+  )
+
+const indexSignatureTypeElement = (
+  indexSignature: AST.IndexSignature,
+): ts.IndexSignatureDeclaration =>
+  ts.factory.createIndexSignature(
+    undefined,
+    [
+      ts.factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        "x",
+        undefined,
+        toTypeNode(indexSignature.parameter),
+        undefined,
+      ),
+    ],
+    toTypeNode(indexSignature.type),
+  )
+
+const objectsTypeNode = (ast: AST.Objects): ts.TypeLiteralNode =>
+  ts.factory.createTypeLiteralNode([
+    ...ast.propertySignatures.map(propertySignatureTypeElement),
+    ...ast.indexSignatures.map(indexSignatureTypeElement),
+  ])
+
 const toTypeNode = (ast: AST.AST): ts.TypeNode => {
   switch (ast._tag) {
     case "String":
@@ -103,6 +207,8 @@ const toTypeNode = (ast: AST.AST): ts.TypeNode => {
       return literalTypeNode(ast)
     case "UniqueSymbol":
       return uniqueSymbolTypeNode(ast)
+    case "Objects":
+      return objectsTypeNode(ast)
     default:
       return unknownTypeNode()
   }


### PR DESCRIPTION
## Summary
- add `Objects` rendering in `src/TypeBuilder.ts` for readonly and optional properties, symbol keys, index signatures, and field JSDoc annotations
- cover structs, mutable and optional keys, symbol properties, records, and mixed struct-with-rest objects in `src/TypeBuilder.test.ts`
- verify the TypeBuilder object/record branch with `pnpm check && pnpm test`