### PR TITLE
TIM-678: render array and tuple schema types

### DIFF
--- a/src/TypeBuilder.test.ts
+++ b/src/TypeBuilder.test.ts
@@ -131,6 +131,59 @@ describe("TypeBuilder", () => {
     )
   })
 
+  it("renders readonly arrays", () => {
+    expect(TypeBuilder.render(Schema.Array(Schema.String))).toBe(
+      "readonly string[]",
+    )
+  })
+
+  it("renders mutable arrays", () => {
+    expect(
+      TypeBuilder.render(Schema.mutable(Schema.Array(Schema.String))),
+    ).toBe("string[]")
+  })
+
+  it("renders readonly tuples", () => {
+    expect(
+      TypeBuilder.render(Schema.Tuple([Schema.String, Schema.Number])),
+    ).toBe(lines("readonly [", "    string,", "    number", "]"))
+  })
+
+  it("renders mutable tuples", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.mutable(Schema.Tuple([Schema.String, Schema.Number])),
+      ),
+    ).toBe(lines("[", "    string,", "    number", "]"))
+  })
+
+  it("renders optional tuple elements", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.Tuple([Schema.String, Schema.optional(Schema.Number)]),
+      ),
+    ).toBe(lines("readonly [", "    string,", "    number?", "]"))
+  })
+
+  it("renders tuples with rest elements", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [
+          Schema.Number,
+          Schema.Boolean,
+        ]),
+      ),
+    ).toBe(
+      lines(
+        "readonly [",
+        "    string,",
+        "    ...number[],",
+        "    boolean",
+        "]",
+      ),
+    )
+  })
+
   it("renders documented fields", () => {
     expect(
       TypeBuilder.render(

--- a/src/TypeBuilder.test.ts
+++ b/src/TypeBuilder.test.ts
@@ -184,6 +184,42 @@ describe("TypeBuilder", () => {
     )
   })
 
+  it("renders unions", () => {
+    expect(
+      TypeBuilder.render(Schema.Union([Schema.String, Schema.Number])),
+    ).toBe("string | number")
+  })
+
+  it("renders optional tuple elements with union members", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.Tuple([
+          Schema.String,
+          Schema.optional(Schema.Union([Schema.Number, Schema.Boolean])),
+        ]),
+      ),
+    ).toBe(lines("readonly [", "    string,", "    (number | boolean)?", "]"))
+  })
+
+  it("renders tuples with composite rest element types", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [
+          Schema.Union([Schema.Number, Schema.Boolean]),
+          Schema.Boolean,
+        ]),
+      ),
+    ).toBe(
+      lines(
+        "readonly [",
+        "    string,",
+        "    ...(number | boolean)[],",
+        "    boolean",
+        "]",
+      ),
+    )
+  })
+
   it("renders documented fields", () => {
     expect(
       TypeBuilder.render(

--- a/src/TypeBuilder.ts
+++ b/src/TypeBuilder.ts
@@ -180,6 +180,20 @@ const objectsTypeNode = (ast: AST.Objects): ts.TypeLiteralNode =>
     ...ast.indexSignatures.map(indexSignatureTypeElement),
   ])
 
+const unionTypeNode = (ast: AST.Union): ts.TypeNode => {
+  const [firstType, ...restTypes] = ast.types
+
+  if (firstType === undefined) {
+    return primitiveTypeNode(ts.SyntaxKind.NeverKeyword)
+  }
+
+  if (restTypes.length === 0) {
+    return toTypeNode(firstType)
+  }
+
+  return ts.factory.createUnionTypeNode(ast.types.map(toTypeNode))
+}
+
 const stripOptionalTupleUndefined = (ast: AST.AST): AST.AST => {
   if (!AST.isOptional(ast) || ast._tag !== "Union") {
     return ast
@@ -188,9 +202,20 @@ const stripOptionalTupleUndefined = (ast: AST.AST): AST.AST => {
   const definedTypes = ast.types.filter((type) => type._tag !== "Undefined")
   const [definedType] = definedTypes
 
+  if (definedTypes.length === ast.types.length) {
+    return ast
+  }
+
   return definedTypes.length === 1 && definedType !== undefined
     ? definedType
-    : ast
+    : new AST.Union(
+        definedTypes,
+        ast.mode,
+        ast.annotations,
+        ast.checks,
+        ast.encoding,
+        ast.context,
+      )
 }
 
 const tupleElementTypeNode = (ast: AST.AST): ts.TypeNode => {
@@ -261,6 +286,8 @@ const toTypeNode = (ast: AST.AST): ts.TypeNode => {
       return objectsTypeNode(ast)
     case "Arrays":
       return arraysTypeNode(ast)
+    case "Union":
+      return unionTypeNode(ast)
     default:
       return unknownTypeNode()
   }

--- a/src/TypeBuilder.ts
+++ b/src/TypeBuilder.ts
@@ -11,6 +11,9 @@ const primitiveTypeNode = (
   kind: ts.KeywordTypeSyntaxKind,
 ): ts.KeywordTypeNode => ts.factory.createKeywordTypeNode(kind)
 
+const readonlyTypeNode = (type: ts.TypeNode): ts.TypeOperatorNode =>
+  ts.factory.createTypeOperatorNode(ts.SyntaxKind.ReadonlyKeyword, type)
+
 const nullTypeNode = (): ts.LiteralTypeNode =>
   ts.factory.createLiteralTypeNode(ts.factory.createNull())
 
@@ -177,6 +180,53 @@ const objectsTypeNode = (ast: AST.Objects): ts.TypeLiteralNode =>
     ...ast.indexSignatures.map(indexSignatureTypeElement),
   ])
 
+const stripOptionalTupleUndefined = (ast: AST.AST): AST.AST => {
+  if (!AST.isOptional(ast) || ast._tag !== "Union") {
+    return ast
+  }
+
+  const definedTypes = ast.types.filter((type) => type._tag !== "Undefined")
+  const [definedType] = definedTypes
+
+  return definedTypes.length === 1 && definedType !== undefined
+    ? definedType
+    : ast
+}
+
+const tupleElementTypeNode = (ast: AST.AST): ts.TypeNode => {
+  const type = toTypeNode(stripOptionalTupleUndefined(ast))
+
+  return AST.isOptional(ast) ? ts.factory.createOptionalTypeNode(type) : type
+}
+
+const arraysTypeNode = (ast: AST.Arrays): ts.TypeNode => {
+  const [restHead, ...restTail] = ast.rest
+
+  if (
+    ast.elements.length === 0 &&
+    ast.rest.length === 1 &&
+    restHead !== undefined
+  ) {
+    const arrayType = ts.factory.createArrayTypeNode(toTypeNode(restHead))
+
+    return ast.isMutable ? arrayType : readonlyTypeNode(arrayType)
+  }
+
+  const tupleType = ts.factory.createTupleTypeNode([
+    ...ast.elements.map(tupleElementTypeNode),
+    ...(restHead === undefined
+      ? []
+      : [
+          ts.factory.createRestTypeNode(
+            ts.factory.createArrayTypeNode(toTypeNode(restHead)),
+          ),
+          ...restTail.map(tupleElementTypeNode),
+        ]),
+  ])
+
+  return ast.isMutable ? tupleType : readonlyTypeNode(tupleType)
+}
+
 const toTypeNode = (ast: AST.AST): ts.TypeNode => {
   switch (ast._tag) {
     case "String":
@@ -209,6 +259,8 @@ const toTypeNode = (ast: AST.AST): ts.TypeNode => {
       return uniqueSymbolTypeNode(ast)
     case "Objects":
       return objectsTypeNode(ast)
+    case "Arrays":
+      return arraysTypeNode(ast)
     default:
       return unknownTypeNode()
   }


### PR DESCRIPTION
## Summary
- add `Arrays` rendering in `src/TypeBuilder.ts` for readonly and mutable arrays, tuples, and tuple rest elements
- preserve optional tuple element syntax by stripping `Undefined` from Effect's optional tuple unions before printing `?`
- cover readonly/mutable arrays, readonly/mutable tuples, optional tuple elements, and rest tuples in `src/TypeBuilder.test.ts`

## Verification
- `pnpm check`
- `pnpm test`