### PR TITLE
TIM-681: add Codex auth token schema and storage helpers

### DIFF
--- a/src/CodexAuth.test.ts
+++ b/src/CodexAuth.test.ts
@@ -1,0 +1,81 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Option } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
+import {
+  STORE_PREFIX,
+  STORE_TOKEN_KEY,
+  TokenData,
+  toCodexAuthKeyValueStore,
+  toTokenStore,
+} from "./CodexAuth.ts"
+
+describe("CodexAuth", () => {
+  it.effect(
+    "persists token data through the prefixed schema store",
+    Effect.fn(function* () {
+      const kvs = yield* KeyValueStore.KeyValueStore
+      const tokenStore = toTokenStore(kvs)
+      const token = new TokenData({
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: 1_700_000_000_000,
+        accountId: Option.some("account_123"),
+      })
+
+      yield* Effect.orDie(tokenStore.set(STORE_TOKEN_KEY, token))
+
+      const stored = yield* Effect.orDie(tokenStore.get(STORE_TOKEN_KEY))
+
+      assert.strictEqual(Option.isSome(stored), true)
+      if (Option.isNone(stored)) {
+        return
+      }
+
+      assert.strictEqual(stored.value.access, token.access)
+      assert.strictEqual(stored.value.refresh, token.refresh)
+      assert.strictEqual(stored.value.expires, token.expires)
+      assert.strictEqual(Option.isSome(stored.value.accountId), true)
+      if (Option.isSome(stored.value.accountId)) {
+        assert.strictEqual(stored.value.accountId.value, "account_123")
+      }
+
+      const rawValue = yield* Effect.orDie(
+        kvs.get(`${STORE_PREFIX}${STORE_TOKEN_KEY}`),
+      )
+      const unprefixedValue = yield* Effect.orDie(kvs.get(STORE_TOKEN_KEY))
+
+      assert.strictEqual(typeof rawValue, "string")
+      assert.strictEqual(unprefixedValue, undefined)
+    }, Effect.provide(KeyValueStore.layerMemory)),
+  )
+
+  it.effect(
+    "round-trips missing account ids as Option.none",
+    Effect.fn(function* () {
+      const kvs = yield* KeyValueStore.KeyValueStore
+      const prefixedStore = toCodexAuthKeyValueStore(kvs)
+      const tokenStore = toTokenStore(kvs)
+      const token = new TokenData({
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: 1_700_000_000_000,
+        accountId: Option.none(),
+      })
+
+      yield* Effect.orDie(tokenStore.set(STORE_TOKEN_KEY, token))
+
+      const stored = yield* Effect.orDie(tokenStore.get(STORE_TOKEN_KEY))
+
+      assert.strictEqual(Option.isSome(stored), true)
+      if (Option.isNone(stored)) {
+        return
+      }
+
+      assert.strictEqual(Option.isNone(stored.value.accountId), true)
+      assert.strictEqual(
+        yield* Effect.orDie(prefixedStore.has(STORE_TOKEN_KEY)),
+        true,
+      )
+    }, Effect.provide(KeyValueStore.layerMemory)),
+  )
+})

--- a/src/CodexAuth.test.ts
+++ b/src/CodexAuth.test.ts
@@ -2,12 +2,19 @@ import { assert, describe, it } from "@effect/vitest"
 import { Effect, Option } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import {
+  CLIENT_ID,
+  CodexAuthError,
+  CODEX_API_BASE,
+  ISSUER,
+  POLLING_SAFETY_MARGIN_MS,
   STORE_PREFIX,
   STORE_TOKEN_KEY,
+  TOKEN_EXPIRY_BUFFER_MS,
   TokenData,
   toCodexAuthKeyValueStore,
   toTokenStore,
 } from "./CodexAuth.ts"
+import * as PublicApi from "./index.ts"
 
 describe("CodexAuth", () => {
   it.effect(
@@ -78,4 +85,51 @@ describe("CodexAuth", () => {
       )
     }, Effect.provide(KeyValueStore.layerMemory)),
   )
+
+  it("marks tokens expired using the refresh buffer", () => {
+    const now = Date.now()
+    const expiredSoon = new TokenData({
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: now + TOKEN_EXPIRY_BUFFER_MS - 1_000,
+      accountId: Option.none(),
+    })
+    const stillValid = new TokenData({
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: now + TOKEN_EXPIRY_BUFFER_MS + 60_000,
+      accountId: Option.none(),
+    })
+
+    assert.strictEqual(expiredSoon.isExpired(), true)
+    assert.strictEqual(stillValid.isExpired(), false)
+  })
+
+  it("constructs CodexAuthError with the expected tagged shape", () => {
+    const error = new CodexAuthError({
+      reason: "JwtParseFailed",
+      message: "Could not decode token claims",
+    })
+
+    assert.strictEqual(error._tag, "CodexAuthError")
+    assert.strictEqual(error.reason, "JwtParseFailed")
+    assert.strictEqual(error.message, "Could not decode token claims")
+  })
+
+  it("re-exports the public Codex auth surface without storage helpers", () => {
+    assert.strictEqual(PublicApi.CLIENT_ID, CLIENT_ID)
+    assert.strictEqual(PublicApi.CODEX_API_BASE, CODEX_API_BASE)
+    assert.strictEqual(PublicApi.ISSUER, ISSUER)
+    assert.strictEqual(
+      PublicApi.POLLING_SAFETY_MARGIN_MS,
+      POLLING_SAFETY_MARGIN_MS,
+    )
+    assert.strictEqual(PublicApi.STORE_PREFIX, STORE_PREFIX)
+    assert.strictEqual(PublicApi.STORE_TOKEN_KEY, STORE_TOKEN_KEY)
+    assert.strictEqual(PublicApi.TOKEN_EXPIRY_BUFFER_MS, TOKEN_EXPIRY_BUFFER_MS)
+    assert.strictEqual(PublicApi.TokenData, TokenData)
+    assert.strictEqual(PublicApi.CodexAuthError, CodexAuthError)
+    assert.strictEqual("toCodexAuthKeyValueStore" in PublicApi, false)
+    assert.strictEqual("toTokenStore" in PublicApi, false)
+  })
 })

--- a/src/CodexAuth.ts
+++ b/src/CodexAuth.ts
@@ -1,0 +1,43 @@
+import { Schema } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
+
+export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+export const ISSUER = "https://auth.openai.com"
+export const CODEX_API_BASE = "https://chatgpt.com/backend-api/codex"
+export const POLLING_SAFETY_MARGIN_MS = 3000
+export const TOKEN_EXPIRY_BUFFER_MS = 30_000
+export const STORE_PREFIX = "codex.auth/"
+export const STORE_TOKEN_KEY = "token"
+
+export class TokenData extends Schema.Class<TokenData>(
+  "clanka/CodexAuth/TokenData",
+)({
+  access: Schema.String,
+  refresh: Schema.String,
+  expires: Schema.Number,
+  accountId: Schema.OptionFromOptional(Schema.String),
+}) {
+  isExpired(): boolean {
+    return this.expires < Date.now() + TOKEN_EXPIRY_BUFFER_MS
+  }
+}
+
+export class CodexAuthError extends Schema.TaggedErrorClass<CodexAuthError>()(
+  "CodexAuthError",
+  {
+    reason: Schema.Literals([
+      "DeviceFlowFailed",
+      "TokenExchangeFailed",
+      "RefreshFailed",
+      "JwtParseFailed",
+    ]),
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect),
+  },
+) {}
+
+export const toCodexAuthKeyValueStore = (store: KeyValueStore.KeyValueStore) =>
+  KeyValueStore.prefix(store, STORE_PREFIX)
+
+export const toTokenStore = (store: KeyValueStore.KeyValueStore) =>
+  KeyValueStore.toSchemaStore(toCodexAuthKeyValueStore(store), TokenData)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,12 @@
 export { program } from "./Example.ts"
-export * from "./CodexAuth.ts"
+export {
+  CLIENT_ID,
+  CODEX_API_BASE,
+  CodexAuthError,
+  ISSUER,
+  POLLING_SAFETY_MARGIN_MS,
+  STORE_PREFIX,
+  STORE_TOKEN_KEY,
+  TOKEN_EXPIRY_BUFFER_MS,
+  TokenData,
+} from "./CodexAuth.ts"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { program } from "./Example.ts"
+export * from "./CodexAuth.ts"


### PR DESCRIPTION
## Summary
- add `src/CodexAuth.ts` with the shared Codex auth constants, `TokenData`, `CodexAuthError`, and `KeyValueStore` storage helpers used for persisted auth state
- export the new Codex auth module from `src/index.ts` so the initial public auth surface is available to consumers
- add `src/CodexAuth.test.ts` coverage for token round-tripping through `KeyValueStore.layerMemory`, including prefixed storage and optional account id persistence

## Checks
- `pnpm check`
- `pnpm vitest run`