### PR TITLE
TIM-682: add Codex auth JWT account parsing helpers

### DIFF
--- a/src/CodexAuth.test.ts
+++ b/src/CodexAuth.test.ts
@@ -206,6 +206,43 @@ describe("CodexAuth", () => {
     )
   })
 
+  it("treats empty root and nested account ids as missing", () => {
+    assert.strictEqual(
+      Option.getOrUndefined(
+        extractAccountIdFromClaims({
+          chatgpt_account_id: "",
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "acc-nested",
+          },
+        }),
+      ),
+      "acc-nested",
+    )
+    assert.strictEqual(
+      Option.getOrUndefined(
+        extractAccountIdFromClaims({
+          chatgpt_account_id: "",
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "",
+          },
+          organizations: [{ id: "org-123" }],
+        }),
+      ),
+      "org-123",
+    )
+  })
+
+  it("returns none when no account id claim is present", () => {
+    assert.strictEqual(
+      Option.isNone(
+        extractAccountIdFromClaims({
+          organizations: [],
+        }),
+      ),
+      true,
+    )
+  })
+
   it("extracts account ids directly from JWTs", () => {
     assert.strictEqual(
       Option.getOrUndefined(

--- a/src/CodexAuth.test.ts
+++ b/src/CodexAuth.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Option } from "effect"
+import { Effect, Encoding, Option } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import {
   CLIENT_ID,
@@ -11,10 +11,19 @@ import {
   STORE_TOKEN_KEY,
   TOKEN_EXPIRY_BUFFER_MS,
   TokenData,
+  extractAccountIdFromClaims,
+  extractAccountIdFromToken,
+  parseJwtClaims,
   toCodexAuthKeyValueStore,
   toTokenStore,
 } from "./CodexAuth.ts"
 import * as PublicApi from "./index.ts"
+
+const createJwt = (payload: string): string =>
+  `${Encoding.encodeBase64Url(JSON.stringify({ alg: "none" }))}.${Encoding.encodeBase64Url(payload)}.sig`
+
+const createTestJwt = (payload: Record<string, unknown>): string =>
+  createJwt(JSON.stringify(payload))
 
 describe("CodexAuth", () => {
   it.effect(
@@ -116,6 +125,106 @@ describe("CodexAuth", () => {
     assert.strictEqual(error.message, "Could not decode token claims")
   })
 
+  it("parses valid JWT claims from a base64url payload", () => {
+    assert.deepStrictEqual(
+      Option.getOrUndefined(
+        parseJwtClaims(
+          createTestJwt({
+            email: "test@example.com",
+            chatgpt_account_id: "acc-123",
+          }),
+        ),
+      ),
+      {
+        chatgpt_account_id: "acc-123",
+      },
+    )
+  })
+
+  it("returns none for JWTs without three parts", () => {
+    assert.strictEqual(Option.isNone(parseJwtClaims("invalid")), true)
+    assert.strictEqual(Option.isNone(parseJwtClaims("only.two")), true)
+  })
+
+  it("returns none for invalid base64url payloads", () => {
+    assert.strictEqual(Option.isNone(parseJwtClaims("a.!!!invalid!!!.b")), true)
+  })
+
+  it("returns none for invalid JSON payloads", () => {
+    assert.strictEqual(
+      Option.isNone(parseJwtClaims(createJwt("not json"))),
+      true,
+    )
+  })
+
+  it("returns none when decoded claims fail the schema", () => {
+    assert.strictEqual(
+      Option.isNone(parseJwtClaims(createTestJwt({ chatgpt_account_id: 123 }))),
+      true,
+    )
+  })
+
+  it("extracts account ids from the documented claim locations", () => {
+    assert.strictEqual(
+      Option.getOrUndefined(
+        extractAccountIdFromClaims({ chatgpt_account_id: "acc-root" }),
+      ),
+      "acc-root",
+    )
+    assert.strictEqual(
+      Option.getOrUndefined(
+        extractAccountIdFromClaims({
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "acc-nested",
+          },
+        }),
+      ),
+      "acc-nested",
+    )
+    assert.strictEqual(
+      Option.getOrUndefined(
+        extractAccountIdFromClaims({
+          organizations: [{ id: "org-123" }, { id: "org-456" }],
+        }),
+      ),
+      "org-123",
+    )
+  })
+
+  it("prefers root claims over nested and organization fallbacks", () => {
+    assert.strictEqual(
+      Option.getOrUndefined(
+        extractAccountIdFromClaims({
+          chatgpt_account_id: "acc-root",
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "acc-nested",
+          },
+          organizations: [{ id: "org-123" }],
+        }),
+      ),
+      "acc-root",
+    )
+  })
+
+  it("extracts account ids directly from JWTs", () => {
+    assert.strictEqual(
+      Option.getOrUndefined(
+        extractAccountIdFromToken(
+          createTestJwt({
+            "https://api.openai.com/auth": {
+              chatgpt_account_id: "acc-token",
+            },
+          }),
+        ),
+      ),
+      "acc-token",
+    )
+    assert.strictEqual(
+      Option.isNone(extractAccountIdFromToken("invalid")),
+      true,
+    )
+  })
+
   it("re-exports the public Codex auth surface without storage helpers", () => {
     assert.strictEqual(PublicApi.CLIENT_ID, CLIENT_ID)
     assert.strictEqual(PublicApi.CODEX_API_BASE, CODEX_API_BASE)
@@ -129,6 +238,9 @@ describe("CodexAuth", () => {
     assert.strictEqual(PublicApi.TOKEN_EXPIRY_BUFFER_MS, TOKEN_EXPIRY_BUFFER_MS)
     assert.strictEqual(PublicApi.TokenData, TokenData)
     assert.strictEqual(PublicApi.CodexAuthError, CodexAuthError)
+    assert.strictEqual("extractAccountIdFromClaims" in PublicApi, false)
+    assert.strictEqual("extractAccountIdFromToken" in PublicApi, false)
+    assert.strictEqual("parseJwtClaims" in PublicApi, false)
     assert.strictEqual("toCodexAuthKeyValueStore" in PublicApi, false)
     assert.strictEqual("toTokenStore" in PublicApi, false)
   })

--- a/src/CodexAuth.ts
+++ b/src/CodexAuth.ts
@@ -78,13 +78,16 @@ export const parseJwtClaims = (token: string): Option.Option<JwtClaims> =>
 export const extractAccountIdFromClaims = (
   claims: JwtClaims,
 ): Option.Option<string> => {
-  if (claims.chatgpt_account_id !== undefined) {
+  if (
+    claims.chatgpt_account_id !== undefined &&
+    claims.chatgpt_account_id !== ""
+  ) {
     return Option.some(claims.chatgpt_account_id)
   }
 
   const nestedAccountId =
     claims["https://api.openai.com/auth"]?.chatgpt_account_id
-  if (nestedAccountId !== undefined) {
+  if (nestedAccountId !== undefined && nestedAccountId !== "") {
     return Option.some(nestedAccountId)
   }
 

--- a/src/CodexAuth.ts
+++ b/src/CodexAuth.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect"
+import { Encoding, Option, Result, Schema } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 
 export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
@@ -35,6 +35,66 @@ export class CodexAuthError extends Schema.TaggedErrorClass<CodexAuthError>()(
     cause: Schema.optional(Schema.Defect),
   },
 ) {}
+
+const JwtAccountClaimSchema = Schema.Struct({
+  chatgpt_account_id: Schema.optional(Schema.String),
+})
+
+const JwtOrganizationSchema = Schema.Struct({
+  id: Schema.String,
+})
+
+const JwtClaimsSchema = Schema.Struct({
+  chatgpt_account_id: Schema.optional(Schema.String),
+  "https://api.openai.com/auth": Schema.optional(JwtAccountClaimSchema),
+  organizations: Schema.optional(Schema.Array(JwtOrganizationSchema)),
+})
+
+export type JwtClaims = typeof JwtClaimsSchema.Type
+
+const decodeJwtClaims = Schema.decodeUnknownOption(
+  Schema.fromJsonString(JwtClaimsSchema),
+)
+
+const decodeJwtPayload = (token: string): Option.Option<string> => {
+  const parts = token.split(".")
+  if (parts.length !== 3) {
+    return Option.none()
+  }
+
+  const payload = parts[1]
+  if (payload === undefined) {
+    return Option.none()
+  }
+
+  return Option.fromNullishOr(
+    Result.getOrUndefined(Encoding.decodeBase64UrlString(payload)),
+  )
+}
+
+export const parseJwtClaims = (token: string): Option.Option<JwtClaims> =>
+  decodeJwtPayload(token).pipe(Option.flatMap(decodeJwtClaims))
+
+export const extractAccountIdFromClaims = (
+  claims: JwtClaims,
+): Option.Option<string> => {
+  if (claims.chatgpt_account_id !== undefined) {
+    return Option.some(claims.chatgpt_account_id)
+  }
+
+  const nestedAccountId =
+    claims["https://api.openai.com/auth"]?.chatgpt_account_id
+  if (nestedAccountId !== undefined) {
+    return Option.some(nestedAccountId)
+  }
+
+  return Option.fromNullishOr(claims.organizations?.[0]?.id)
+}
+
+export const extractAccountIdFromToken = (
+  token: string,
+): Option.Option<string> =>
+  parseJwtClaims(token).pipe(Option.flatMap(extractAccountIdFromClaims))
 
 export const toCodexAuthKeyValueStore = (store: KeyValueStore.KeyValueStore) =>
   KeyValueStore.prefix(store, STORE_PREFIX)


### PR DESCRIPTION
## Summary
- add pure Codex JWT helpers in `src/CodexAuth.ts` that decode base64url payloads with Effect schemas and extract account ids from the documented claim locations
- add focused coverage in `src/CodexAuth.test.ts` for supported claim precedence plus malformed token, base64url, JSON, and schema-decoding cases
- keep the new parsing helpers off the package-root API by leaving `src/index.ts` unchanged

## Checks
- pnpm check
- pnpm vitest run