### PR TITLE
TIM-684: add Codex OAuth HTTP primitives

### DIFF
--- a/src/CodexAuth.test.ts
+++ b/src/CodexAuth.test.ts
@@ -3,6 +3,7 @@ import { Effect, Encoding, Fiber, Option, Ref } from "effect"
 import { TestClock } from "effect/testing"
 import {
   HttpClient,
+  HttpClientError,
   HttpClientRequest,
   HttpClientResponse,
 } from "effect/unstable/http"
@@ -350,6 +351,38 @@ describe("CodexAuth", () => {
     }),
   )
 
+  it.effect("captures transport failures when requesting a device code", () =>
+    Effect.gen(function* () {
+      const cause = new Error("boom")
+      const client = HttpClient.make((request) =>
+        Effect.fail(
+          new HttpClientError.HttpClientError({
+            reason: new HttpClientError.TransportError({
+              request,
+              cause,
+            }),
+          }),
+        ),
+      )
+
+      const error = yield* requestDeviceCode().pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+        Effect.flip,
+      )
+
+      assert.strictEqual(error.reason, "DeviceFlowFailed")
+      assert.strictEqual(
+        error.message,
+        "Failed to request a Codex device authorization code",
+      )
+      assert.strictEqual(HttpClientError.isHttpClientError(error.cause), true)
+      if (!HttpClientError.isHttpClientError(error.cause)) {
+        assert.fail("Expected an HttpClientError cause")
+      }
+      assert.strictEqual(error.cause.cause, cause)
+    }),
+  )
+
   it.effect(
     "treats 404 and 403 poll responses as pending with the safety delay",
     () =>
@@ -517,6 +550,26 @@ describe("CodexAuth", () => {
         assert.strictEqual(body.get("refresh_token"), "refresh-token")
         assert.strictEqual(body.get("client_id"), CLIENT_ID)
       }),
+  )
+
+  it.effect("captures decode failures when refreshing tokens", () =>
+    Effect.gen(function* () {
+      const { client } = yield* makeClient(() =>
+        jsonResponse({ access_token: "access-token" }),
+      )
+
+      const error = yield* refreshToken("refresh-token").pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+        Effect.flip,
+      )
+
+      assert.strictEqual(error.reason, "RefreshFailed")
+      assert.strictEqual(
+        error.message,
+        "Failed to decode the Codex refresh token response",
+      )
+      assert.notStrictEqual(error.cause, undefined)
+    }),
   )
 
   it("re-exports the public Codex auth surface without storage helpers", () => {

--- a/src/CodexAuth.test.ts
+++ b/src/CodexAuth.test.ts
@@ -1,12 +1,22 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Encoding, Option } from "effect"
+import { Effect, Encoding, Fiber, Option, Ref } from "effect"
+import { TestClock } from "effect/testing"
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http"
 import { KeyValueStore } from "effect/unstable/persistence"
 import {
+  exchangeAuthorizationCode,
   CLIENT_ID,
   CodexAuthError,
   CODEX_API_BASE,
   ISSUER,
   POLLING_SAFETY_MARGIN_MS,
+  pollAuthorization,
+  refreshToken,
+  requestDeviceCode,
   STORE_PREFIX,
   STORE_TOKEN_KEY,
   TOKEN_EXPIRY_BUFFER_MS,
@@ -24,6 +34,47 @@ const createJwt = (payload: string): string =>
 
 const createTestJwt = (payload: Record<string, unknown>): string =>
   createJwt(JSON.stringify(payload))
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  })
+
+const getBody = (request: HttpClientRequest.HttpClientRequest): string => {
+  if (request.body._tag !== "Uint8Array") {
+    throw new Error("Expected request body to be a Uint8Array payload")
+  }
+
+  return new TextDecoder().decode(request.body.body)
+}
+
+const makeClient = Effect.fn("makeClient")(function* (
+  handler: (
+    request: HttpClientRequest.HttpClientRequest,
+    attempt: number,
+  ) => Response,
+) {
+  const attempts = yield* Ref.make(0)
+  const requests = yield* Ref.make<Array<HttpClientRequest.HttpClientRequest>>(
+    [],
+  )
+  const client = HttpClient.make((request) =>
+    Effect.gen(function* () {
+      const attempt = yield* Ref.updateAndGet(attempts, (count) => count + 1)
+      yield* Ref.update(requests, (current) => [...current, request])
+      return HttpClientResponse.fromWeb(request, handler(request, attempt))
+    }),
+  )
+
+  return {
+    attempts,
+    client,
+    requests,
+  } as const
+})
 
 describe("CodexAuth", () => {
   it.effect(
@@ -262,6 +313,212 @@ describe("CodexAuth", () => {
     )
   })
 
+  it.effect("requests a device code with the documented JSON payload", () =>
+    Effect.gen(function* () {
+      const { client, requests } = yield* makeClient(() =>
+        jsonResponse({
+          device_auth_id: "device-auth-id",
+          user_code: "ABCD-EFGH",
+          interval: "0",
+        }),
+      )
+
+      const device = yield* requestDeviceCode().pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+      )
+
+      assert.deepStrictEqual(device, {
+        deviceAuthId: "device-auth-id",
+        userCode: "ABCD-EFGH",
+        intervalMs: 5_000,
+      })
+
+      const request = (yield* Ref.get(requests))[0]
+      assert.notStrictEqual(request, undefined)
+      if (request === undefined) {
+        return
+      }
+
+      assert.strictEqual(request.method, "POST")
+      assert.strictEqual(
+        request.url,
+        `${ISSUER}/api/accounts/deviceauth/usercode`,
+      )
+      assert.deepStrictEqual(JSON.parse(getBody(request)), {
+        client_id: CLIENT_ID,
+      })
+    }),
+  )
+
+  it.effect(
+    "treats 404 and 403 poll responses as pending with the safety delay",
+    () =>
+      Effect.gen(function* () {
+        const { attempts, client, requests } = yield* makeClient(
+          (_request, attempt) => {
+            if (attempt === 1) {
+              return new Response(null, { status: 404 })
+            }
+
+            if (attempt === 2) {
+              return new Response(null, { status: 403 })
+            }
+
+            return jsonResponse({
+              authorization_code: "authorization-code",
+              code_verifier: "code-verifier",
+            })
+          },
+        )
+
+        const fiber = yield* pollAuthorization({
+          deviceAuthId: "device-auth-id",
+          userCode: "ABCD-EFGH",
+          intervalMs: 2_000,
+        }).pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+          Effect.forkChild({ startImmediately: true }),
+        )
+
+        assert.strictEqual(yield* Ref.get(attempts), 1)
+
+        yield* TestClock.adjust(2_000 + POLLING_SAFETY_MARGIN_MS - 1)
+        assert.strictEqual(yield* Ref.get(attempts), 1)
+
+        yield* TestClock.adjust(1)
+        assert.strictEqual(yield* Ref.get(attempts), 2)
+
+        yield* TestClock.adjust(2_000 + POLLING_SAFETY_MARGIN_MS)
+
+        assert.deepStrictEqual(yield* Fiber.join(fiber), {
+          authorizationCode: "authorization-code",
+          codeVerifier: "code-verifier",
+        })
+        assert.strictEqual(yield* Ref.get(attempts), 3)
+
+        const request = (yield* Ref.get(requests))[0]
+        assert.notStrictEqual(request, undefined)
+        if (request === undefined) {
+          return
+        }
+
+        assert.deepStrictEqual(JSON.parse(getBody(request)), {
+          device_auth_id: "device-auth-id",
+          user_code: "ABCD-EFGH",
+        })
+      }),
+  )
+
+  it.effect("fails polling on terminal statuses outside the pending set", () =>
+    Effect.gen(function* () {
+      const { client } = yield* makeClient(
+        () => new Response(null, { status: 500 }),
+      )
+
+      const error = yield* pollAuthorization({
+        deviceAuthId: "device-auth-id",
+        userCode: "ABCD-EFGH",
+        intervalMs: 1_000,
+      }).pipe(Effect.provideService(HttpClient.HttpClient, client), Effect.flip)
+
+      assert.strictEqual(error.reason, "DeviceFlowFailed")
+      assert.strictEqual(
+        error.message,
+        "Codex device authorization failed while polling: 500",
+      )
+    }),
+  )
+
+  it.effect(
+    "exchanges authorization codes with urlencoded payloads and id token precedence",
+    () =>
+      Effect.gen(function* () {
+        const before = Date.now()
+        const { client, requests } = yield* makeClient(() =>
+          jsonResponse({
+            id_token: createTestJwt({ chatgpt_account_id: "from-id-token" }),
+            access_token: createTestJwt({
+              chatgpt_account_id: "from-access-token",
+            }),
+            refresh_token: "refresh-token",
+            expires_in: 42,
+          }),
+        )
+
+        const token = yield* exchangeAuthorizationCode({
+          authorizationCode: "authorization-code",
+          codeVerifier: "code-verifier",
+        }).pipe(Effect.provideService(HttpClient.HttpClient, client))
+
+        assert.strictEqual(token.access.includes("."), true)
+        assert.strictEqual(token.refresh, "refresh-token")
+        assert.strictEqual(
+          Option.getOrUndefined(token.accountId),
+          "from-id-token",
+        )
+        assert.strictEqual(token.expires >= before + 42_000, true)
+        assert.strictEqual(token.expires <= Date.now() + 42_000, true)
+
+        const request = (yield* Ref.get(requests))[0]
+        assert.notStrictEqual(request, undefined)
+        if (request === undefined) {
+          return
+        }
+
+        assert.strictEqual(request.method, "POST")
+        assert.strictEqual(request.url, `${ISSUER}/oauth/token`)
+
+        const body = new URLSearchParams(getBody(request))
+        assert.strictEqual(body.get("grant_type"), "authorization_code")
+        assert.strictEqual(body.get("code"), "authorization-code")
+        assert.strictEqual(
+          body.get("redirect_uri"),
+          `${ISSUER}/deviceauth/callback`,
+        )
+        assert.strictEqual(body.get("client_id"), CLIENT_ID)
+        assert.strictEqual(body.get("code_verifier"), "code-verifier")
+      }),
+  )
+
+  it.effect(
+    "refreshes tokens with urlencoded payloads and access token fallback",
+    () =>
+      Effect.gen(function* () {
+        const { client, requests } = yield* makeClient(() =>
+          jsonResponse({
+            id_token: createTestJwt({ email: "test@example.com" }),
+            access_token: createTestJwt({
+              "https://api.openai.com/auth": {
+                chatgpt_account_id: "from-access-token",
+              },
+            }),
+            refresh_token: "next-refresh-token",
+          }),
+        )
+
+        const token = yield* refreshToken("refresh-token").pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+        )
+
+        assert.strictEqual(token.refresh, "next-refresh-token")
+        assert.strictEqual(
+          Option.getOrUndefined(token.accountId),
+          "from-access-token",
+        )
+
+        const request = (yield* Ref.get(requests))[0]
+        assert.notStrictEqual(request, undefined)
+        if (request === undefined) {
+          return
+        }
+
+        const body = new URLSearchParams(getBody(request))
+        assert.strictEqual(body.get("grant_type"), "refresh_token")
+        assert.strictEqual(body.get("refresh_token"), "refresh-token")
+        assert.strictEqual(body.get("client_id"), CLIENT_ID)
+      }),
+  )
+
   it("re-exports the public Codex auth surface without storage helpers", () => {
     assert.strictEqual(PublicApi.CLIENT_ID, CLIENT_ID)
     assert.strictEqual(PublicApi.CODEX_API_BASE, CODEX_API_BASE)
@@ -275,9 +532,13 @@ describe("CodexAuth", () => {
     assert.strictEqual(PublicApi.TOKEN_EXPIRY_BUFFER_MS, TOKEN_EXPIRY_BUFFER_MS)
     assert.strictEqual(PublicApi.TokenData, TokenData)
     assert.strictEqual(PublicApi.CodexAuthError, CodexAuthError)
+    assert.strictEqual("exchangeAuthorizationCode" in PublicApi, false)
     assert.strictEqual("extractAccountIdFromClaims" in PublicApi, false)
     assert.strictEqual("extractAccountIdFromToken" in PublicApi, false)
     assert.strictEqual("parseJwtClaims" in PublicApi, false)
+    assert.strictEqual("pollAuthorization" in PublicApi, false)
+    assert.strictEqual("refreshToken" in PublicApi, false)
+    assert.strictEqual("requestDeviceCode" in PublicApi, false)
     assert.strictEqual("toCodexAuthKeyValueStore" in PublicApi, false)
     assert.strictEqual("toTokenStore" in PublicApi, false)
   })

--- a/src/CodexAuth.ts
+++ b/src/CodexAuth.ts
@@ -173,22 +173,25 @@ const toTokenDataFromResponse = (token: TokenResponse): TokenData =>
     accountId: extractAccountIdFromTokens(token),
   })
 
-const requestDeviceCodeError = (message: string) =>
+const requestDeviceCodeError = (message: string, cause?: unknown) =>
   new CodexAuthError({
     reason: "DeviceFlowFailed",
     message,
+    ...(cause === undefined ? {} : { cause }),
   })
 
-const tokenExchangeError = (message: string) =>
+const tokenExchangeError = (message: string, cause?: unknown) =>
   new CodexAuthError({
     reason: "TokenExchangeFailed",
     message,
+    ...(cause === undefined ? {} : { cause }),
   })
 
-const refreshTokenError = (message: string) =>
+const refreshTokenError = (message: string, cause?: unknown) =>
   new CodexAuthError({
     reason: "RefreshFailed",
     message,
+    ...(cause === undefined ? {} : { cause }),
   })
 
 export const requestDeviceCode = Effect.fn("CodexAuth.requestDeviceCode")(
@@ -202,9 +205,10 @@ export const requestDeviceCode = Effect.fn("CodexAuth.requestDeviceCode")(
         client_id: CLIENT_ID,
       }),
       HttpClient.execute,
-      Effect.mapError(() =>
+      Effect.mapError((cause) =>
         requestDeviceCodeError(
           "Failed to request a Codex device authorization code",
+          cause,
         ),
       ),
     )
@@ -218,9 +222,10 @@ export const requestDeviceCode = Effect.fn("CodexAuth.requestDeviceCode")(
     const payload = yield* HttpClientResponse.schemaBodyJson(
       DeviceCodeResponseSchema,
     )(response).pipe(
-      Effect.mapError(() =>
+      Effect.mapError((cause) =>
         requestDeviceCodeError(
           "Failed to decode the Codex device authorization response",
+          cause,
         ),
       ),
     )
@@ -256,17 +261,21 @@ export const pollAuthorization = Effect.fn("CodexAuth.pollAuthorization")(
       HttpClient.HttpClient
     > = Effect.suspend(() =>
       HttpClient.execute(request).pipe(
-        Effect.mapError(() =>
-          requestDeviceCodeError("Failed to poll Codex device authorization"),
+        Effect.mapError((cause) =>
+          requestDeviceCodeError(
+            "Failed to poll Codex device authorization",
+            cause,
+          ),
         ),
         Effect.flatMap((response) => {
           if (response.status === 200) {
             return HttpClientResponse.schemaBodyJson(
               AuthorizationCodeResponseSchema,
             )(response).pipe(
-              Effect.mapError(() =>
+              Effect.mapError((cause) =>
                 requestDeviceCodeError(
                   "Failed to decode the Codex authorization approval response",
+                  cause,
                 ),
               ),
               Effect.map((payload) => ({
@@ -307,8 +316,11 @@ export const exchangeAuthorizationCode = Effect.fn(
       code_verifier: authorization.codeVerifier,
     }),
     HttpClient.execute,
-    Effect.mapError(() =>
-      tokenExchangeError("Failed to exchange the Codex authorization code"),
+    Effect.mapError((cause) =>
+      tokenExchangeError(
+        "Failed to exchange the Codex authorization code",
+        cause,
+      ),
     ),
   )
 
@@ -321,8 +333,11 @@ export const exchangeAuthorizationCode = Effect.fn(
   const payload = yield* HttpClientResponse.schemaBodyJson(TokenResponseSchema)(
     response,
   ).pipe(
-    Effect.mapError(() =>
-      tokenExchangeError("Failed to decode the Codex token exchange response"),
+    Effect.mapError((cause) =>
+      tokenExchangeError(
+        "Failed to decode the Codex token exchange response",
+        cause,
+      ),
     ),
   )
 
@@ -339,8 +354,8 @@ export const refreshToken = Effect.fn("CodexAuth.refreshToken")(function* (
       client_id: CLIENT_ID,
     }),
     HttpClient.execute,
-    Effect.mapError(() =>
-      refreshTokenError("Failed to refresh the Codex access token"),
+    Effect.mapError((cause) =>
+      refreshTokenError("Failed to refresh the Codex access token", cause),
     ),
   )
 
@@ -353,8 +368,11 @@ export const refreshToken = Effect.fn("CodexAuth.refreshToken")(function* (
   const payload = yield* HttpClientResponse.schemaBodyJson(TokenResponseSchema)(
     response,
   ).pipe(
-    Effect.mapError(() =>
-      refreshTokenError("Failed to decode the Codex refresh token response"),
+    Effect.mapError((cause) =>
+      refreshTokenError(
+        "Failed to decode the Codex refresh token response",
+        cause,
+      ),
     ),
   )
 

--- a/src/CodexAuth.ts
+++ b/src/CodexAuth.ts
@@ -1,4 +1,9 @@
-import { Encoding, Option, Result, Schema } from "effect"
+import { Effect, Encoding, Option, Result, Schema } from "effect"
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http"
 import { KeyValueStore } from "effect/unstable/persistence"
 
 export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
@@ -8,6 +13,13 @@ export const POLLING_SAFETY_MARGIN_MS = 3000
 export const TOKEN_EXPIRY_BUFFER_MS = 30_000
 export const STORE_PREFIX = "codex.auth/"
 export const STORE_TOKEN_KEY = "token"
+
+const DEVICE_CODE_URL = `${ISSUER}/api/accounts/deviceauth/usercode`
+const DEVICE_TOKEN_URL = `${ISSUER}/api/accounts/deviceauth/token`
+const TOKEN_URL = `${ISSUER}/oauth/token`
+const DEVICE_REDIRECT_URI = `${ISSUER}/deviceauth/callback`
+const DEFAULT_DEVICE_POLL_INTERVAL_SECONDS = 5
+const DEFAULT_TOKEN_EXPIRY_SECONDS = 3600
 
 export class TokenData extends Schema.Class<TokenData>(
   "clanka/CodexAuth/TokenData",
@@ -35,6 +47,37 @@ export class CodexAuthError extends Schema.TaggedErrorClass<CodexAuthError>()(
     cause: Schema.optional(Schema.Defect),
   },
 ) {}
+
+const DeviceCodeResponseSchema = Schema.Struct({
+  device_auth_id: Schema.String,
+  user_code: Schema.String,
+  interval: Schema.String,
+})
+
+const AuthorizationCodeResponseSchema = Schema.Struct({
+  authorization_code: Schema.String,
+  code_verifier: Schema.String,
+})
+
+const TokenResponseSchema = Schema.Struct({
+  id_token: Schema.optional(Schema.String),
+  access_token: Schema.String,
+  refresh_token: Schema.String,
+  expires_in: Schema.optional(Schema.Number),
+})
+
+type TokenResponse = typeof TokenResponseSchema.Type
+
+export interface DeviceCodeData {
+  readonly deviceAuthId: string
+  readonly userCode: string
+  readonly intervalMs: number
+}
+
+export interface AuthorizationCodeData {
+  readonly authorizationCode: string
+  readonly codeVerifier: string
+}
 
 const JwtAccountClaimSchema = Schema.Struct({
   chatgpt_account_id: Schema.optional(Schema.String),
@@ -98,6 +141,225 @@ export const extractAccountIdFromToken = (
   token: string,
 ): Option.Option<string> =>
   parseJwtClaims(token).pipe(Option.flatMap(extractAccountIdFromClaims))
+
+const isSuccessfulStatus = (status: number): boolean =>
+  status >= 200 && status < 300
+
+const normalizePollInterval = (interval: string): number =>
+  Math.max(
+    Number.parseInt(interval, 10) || DEFAULT_DEVICE_POLL_INTERVAL_SECONDS,
+    1,
+  ) * 1_000
+
+const extractAccountIdFromTokens = (
+  token: TokenResponse,
+): Option.Option<string> => {
+  if (token.id_token !== undefined && token.id_token !== "") {
+    const accountId = extractAccountIdFromToken(token.id_token)
+    if (Option.isSome(accountId)) {
+      return accountId
+    }
+  }
+
+  return extractAccountIdFromToken(token.access_token)
+}
+
+const toTokenDataFromResponse = (token: TokenResponse): TokenData =>
+  new TokenData({
+    access: token.access_token,
+    refresh: token.refresh_token,
+    expires:
+      Date.now() + (token.expires_in ?? DEFAULT_TOKEN_EXPIRY_SECONDS) * 1_000,
+    accountId: extractAccountIdFromTokens(token),
+  })
+
+const requestDeviceCodeError = (message: string) =>
+  new CodexAuthError({
+    reason: "DeviceFlowFailed",
+    message,
+  })
+
+const tokenExchangeError = (message: string) =>
+  new CodexAuthError({
+    reason: "TokenExchangeFailed",
+    message,
+  })
+
+const refreshTokenError = (message: string) =>
+  new CodexAuthError({
+    reason: "RefreshFailed",
+    message,
+  })
+
+export const requestDeviceCode = Effect.fn("CodexAuth.requestDeviceCode")(
+  function* (): Effect.fn.Return<
+    DeviceCodeData,
+    CodexAuthError,
+    HttpClient.HttpClient
+  > {
+    const response = yield* HttpClientRequest.post(DEVICE_CODE_URL).pipe(
+      HttpClientRequest.bodyJsonUnsafe({
+        client_id: CLIENT_ID,
+      }),
+      HttpClient.execute,
+      Effect.mapError(() =>
+        requestDeviceCodeError(
+          "Failed to request a Codex device authorization code",
+        ),
+      ),
+    )
+
+    if (!isSuccessfulStatus(response.status)) {
+      return yield* requestDeviceCodeError(
+        `Failed to request a Codex device authorization code: ${response.status}`,
+      )
+    }
+
+    const payload = yield* HttpClientResponse.schemaBodyJson(
+      DeviceCodeResponseSchema,
+    )(response).pipe(
+      Effect.mapError(() =>
+        requestDeviceCodeError(
+          "Failed to decode the Codex device authorization response",
+        ),
+      ),
+    )
+
+    return {
+      deviceAuthId: payload.device_auth_id,
+      userCode: payload.user_code,
+      intervalMs: normalizePollInterval(payload.interval),
+    }
+  },
+)
+
+export const pollAuthorization = Effect.fn("CodexAuth.pollAuthorization")(
+  function* (
+    deviceCode: DeviceCodeData,
+  ): Effect.fn.Return<
+    AuthorizationCodeData,
+    CodexAuthError,
+    HttpClient.HttpClient
+  > {
+    const request = HttpClientRequest.post(DEVICE_TOKEN_URL).pipe(
+      HttpClientRequest.bodyJsonUnsafe({
+        device_auth_id: deviceCode.deviceAuthId,
+        user_code: deviceCode.userCode,
+      }),
+    )
+
+    const delayMs = deviceCode.intervalMs + POLLING_SAFETY_MARGIN_MS
+
+    const loop: Effect.Effect<
+      AuthorizationCodeData,
+      CodexAuthError,
+      HttpClient.HttpClient
+    > = Effect.suspend(() =>
+      HttpClient.execute(request).pipe(
+        Effect.mapError(() =>
+          requestDeviceCodeError("Failed to poll Codex device authorization"),
+        ),
+        Effect.flatMap((response) => {
+          if (response.status === 200) {
+            return HttpClientResponse.schemaBodyJson(
+              AuthorizationCodeResponseSchema,
+            )(response).pipe(
+              Effect.mapError(() =>
+                requestDeviceCodeError(
+                  "Failed to decode the Codex authorization approval response",
+                ),
+              ),
+              Effect.map((payload) => ({
+                authorizationCode: payload.authorization_code,
+                codeVerifier: payload.code_verifier,
+              })),
+            )
+          }
+
+          if (response.status === 403 || response.status === 404) {
+            return Effect.sleep(delayMs).pipe(Effect.andThen(loop))
+          }
+
+          return Effect.fail(
+            requestDeviceCodeError(
+              `Codex device authorization failed while polling: ${response.status}`,
+            ),
+          )
+        }),
+      ),
+    )
+
+    return yield* loop
+  },
+)
+
+export const exchangeAuthorizationCode = Effect.fn(
+  "CodexAuth.exchangeAuthorizationCode",
+)(function* (
+  authorization: AuthorizationCodeData,
+): Effect.fn.Return<TokenData, CodexAuthError, HttpClient.HttpClient> {
+  const response = yield* HttpClientRequest.post(TOKEN_URL).pipe(
+    HttpClientRequest.bodyUrlParams({
+      grant_type: "authorization_code",
+      code: authorization.authorizationCode,
+      redirect_uri: DEVICE_REDIRECT_URI,
+      client_id: CLIENT_ID,
+      code_verifier: authorization.codeVerifier,
+    }),
+    HttpClient.execute,
+    Effect.mapError(() =>
+      tokenExchangeError("Failed to exchange the Codex authorization code"),
+    ),
+  )
+
+  if (!isSuccessfulStatus(response.status)) {
+    return yield* tokenExchangeError(
+      `Codex token exchange failed: ${response.status}`,
+    )
+  }
+
+  const payload = yield* HttpClientResponse.schemaBodyJson(TokenResponseSchema)(
+    response,
+  ).pipe(
+    Effect.mapError(() =>
+      tokenExchangeError("Failed to decode the Codex token exchange response"),
+    ),
+  )
+
+  return toTokenDataFromResponse(payload)
+})
+
+export const refreshToken = Effect.fn("CodexAuth.refreshToken")(function* (
+  refresh: string,
+): Effect.fn.Return<TokenData, CodexAuthError, HttpClient.HttpClient> {
+  const response = yield* HttpClientRequest.post(TOKEN_URL).pipe(
+    HttpClientRequest.bodyUrlParams({
+      grant_type: "refresh_token",
+      refresh_token: refresh,
+      client_id: CLIENT_ID,
+    }),
+    HttpClient.execute,
+    Effect.mapError(() =>
+      refreshTokenError("Failed to refresh the Codex access token"),
+    ),
+  )
+
+  if (!isSuccessfulStatus(response.status)) {
+    return yield* refreshTokenError(
+      `Codex token refresh failed: ${response.status}`,
+    )
+  }
+
+  const payload = yield* HttpClientResponse.schemaBodyJson(TokenResponseSchema)(
+    response,
+  ).pipe(
+    Effect.mapError(() =>
+      refreshTokenError("Failed to decode the Codex refresh token response"),
+    ),
+  )
+
+  return toTokenDataFromResponse(payload)
+})
 
 export const toCodexAuthKeyValueStore = (store: KeyValueStore.KeyValueStore) =>
   KeyValueStore.prefix(store, STORE_PREFIX)


### PR DESCRIPTION
## Summary
- add reusable Codex device-flow effects for requesting device codes, polling approval, exchanging authorization codes, and refreshing tokens
- normalize exchange and refresh responses into `TokenData`, including id_token-first account-id extraction for later auth-layer reuse
- add deterministic `HttpClient` and `TestClock` coverage for payload encoding, pending poll delays, and terminal poll failures

## Testing
- pnpm check
- pnpm vitest run