### PR TITLE
TIM-686: render top-level schema documentation comments

### DIFF
--- a/src/TypeBuilder.test.ts
+++ b/src/TypeBuilder.test.ts
@@ -409,4 +409,29 @@ describe("TypeBuilder", () => {
       ),
     ).toBe(lines("/** Token list */", "readonly string[]"))
   })
+
+  it("renders documented recursive schemas at the top level", () => {
+    type Category = {
+      readonly child?: Category
+    }
+
+    const Category: Schema.Schema<Category> = Schema.suspend(
+      (): Schema.Schema<Category> =>
+        Schema.Struct({
+          child: Schema.optionalKey(Category),
+        }).annotate({
+          documentation: "Recursive category",
+          identifier: "Category",
+        }),
+    )
+
+    expect(TypeBuilder.render(Category)).toBe(
+      lines(
+        "/** Recursive category */",
+        "{",
+        "    readonly child?: Category;",
+        "}",
+      ),
+    )
+  })
 })

--- a/src/TypeBuilder.test.ts
+++ b/src/TypeBuilder.test.ts
@@ -381,4 +381,32 @@ describe("TypeBuilder", () => {
       ),
     )
   })
+
+  it("renders documented primitive schemas at the top level", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.String.annotate({ documentation: "Primary token" }),
+      ),
+    ).toBe(lines("/** Primary token */", "string"))
+  })
+
+  it("renders documented object schemas at the top level", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.Struct({
+          token: Schema.String,
+        }).annotate({ documentation: "Token payload" }),
+      ),
+    ).toBe(
+      lines("/** Token payload */", "{", "    readonly token: string;", "}"),
+    )
+  })
+
+  it("renders documented array schemas at the top level", () => {
+    expect(
+      TypeBuilder.render(
+        Schema.Array(Schema.String).annotate({ documentation: "Token list" }),
+      ),
+    ).toBe(lines("/** Token list */", "readonly string[]"))
+  })
 })

--- a/src/TypeBuilder.ts
+++ b/src/TypeBuilder.ts
@@ -498,8 +498,14 @@ export const printNode = (
 export const render = (
   schema: Schema.Top,
   options?: ts.PrinterOptions,
-): string =>
-  printNode(
-    toTypeNode(AST.toType(schema.ast), { activeNodes: new Set() }),
+): string => {
+  const ast = AST.toType(schema.ast)
+
+  return printNode(
+    withJsDoc(
+      toTypeNode(ast, { activeNodes: new Set() }),
+      resolveDocumentation(ast),
+    ),
     options,
   )
+}

--- a/src/TypeBuilder.ts
+++ b/src/TypeBuilder.ts
@@ -187,6 +187,26 @@ const withJsDoc = <T extends ts.Node>(
   return node
 }
 
+const rootDocumentation = (ast: AST.AST): string | undefined => {
+  const visitedSuspends = new Set<AST.Suspend>()
+  let current: AST.AST = ast
+
+  while (true) {
+    const documentation = resolveDocumentation(current)
+
+    if (documentation !== undefined) {
+      return documentation
+    }
+
+    if (current._tag !== "Suspend" || visitedSuspends.has(current)) {
+      return undefined
+    }
+
+    visitedSuspends.add(current)
+    current = current.thunk()
+  }
+}
+
 const propertySignatureTypeElement = (
   propertySignature: AST.PropertySignature,
   context: RenderContext,
@@ -504,7 +524,7 @@ export const render = (
   return printNode(
     withJsDoc(
       toTypeNode(ast, { activeNodes: new Set() }),
-      resolveDocumentation(ast),
+      rootDocumentation(ast),
     ),
     options,
   )


### PR DESCRIPTION
## Summary
- include the detached-HEAD base commits for Codex auth JWT helpers and `TypeBuilder` declaration / suspend rendering that are already present on this branch
- preserve root-level `documentation` annotations in `TypeBuilder.render` so non-property schemas emit JSDoc comments
- add coverage for documented primitive, object, and array schemas and verify with `pnpm check` and `pnpm test`