### PR TITLE
TIM-683: wire Codex auth token lifecycle

### DIFF
--- a/src/CodexAuth.test.ts
+++ b/src/CodexAuth.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Encoding, Fiber, Option, Ref } from "effect"
+import { Deferred, Effect, Encoding, Fiber, Option, Ref } from "effect"
 import { TestClock } from "effect/testing"
 import {
   HttpClient,
@@ -11,6 +11,7 @@ import { KeyValueStore } from "effect/unstable/persistence"
 import {
   exchangeAuthorizationCode,
   CLIENT_ID,
+  CodexAuth,
   CodexAuthError,
   CODEX_API_BASE,
   ISSUER,
@@ -67,6 +68,34 @@ const makeClient = Effect.fn("makeClient")(function* (
       const attempt = yield* Ref.updateAndGet(attempts, (count) => count + 1)
       yield* Ref.update(requests, (current) => [...current, request])
       return HttpClientResponse.fromWeb(request, handler(request, attempt))
+    }),
+  )
+
+  return {
+    attempts,
+    client,
+    requests,
+  } as const
+})
+
+const makeEffectClient = Effect.fn("makeEffectClient")(function* (
+  handler: (
+    request: HttpClientRequest.HttpClientRequest,
+    attempt: number,
+  ) => Effect.Effect<Response>,
+) {
+  const attempts = yield* Ref.make(0)
+  const requests = yield* Ref.make<Array<HttpClientRequest.HttpClientRequest>>(
+    [],
+  )
+  const client = HttpClient.make((request) =>
+    Effect.gen(function* () {
+      const attempt = yield* Ref.updateAndGet(attempts, (count) => count + 1)
+      yield* Ref.update(requests, (current) => [...current, request])
+      return HttpClientResponse.fromWeb(
+        request,
+        yield* handler(request, attempt),
+      )
     }),
   )
 
@@ -572,8 +601,322 @@ describe("CodexAuth", () => {
     }),
   )
 
+  it.effect(
+    "falls back to device auth when refreshing an expired token fails",
+    () =>
+      Effect.gen(function* () {
+        const kvs = yield* KeyValueStore.KeyValueStore
+        const tokenStore = toTokenStore(kvs)
+        yield* Effect.orDie(
+          tokenStore.set(
+            STORE_TOKEN_KEY,
+            new TokenData({
+              access: "stale-access-token",
+              refresh: "stale-refresh-token",
+              expires: Date.now() - 60_000,
+              accountId: Option.some("stale-account"),
+            }),
+          ),
+        )
+
+        const { client, requests } = yield* makeClient((request) => {
+          if (request.url === `${ISSUER}/api/accounts/deviceauth/usercode`) {
+            return jsonResponse({
+              device_auth_id: "device-auth-id",
+              user_code: "WXYZ-9876",
+              interval: "1",
+            })
+          }
+
+          if (request.url === `${ISSUER}/api/accounts/deviceauth/token`) {
+            return jsonResponse({
+              authorization_code: "authorization-code",
+              code_verifier: "code-verifier",
+            })
+          }
+
+          if (request.url === `${ISSUER}/oauth/token`) {
+            const body = new URLSearchParams(getBody(request))
+            if (body.get("grant_type") === "refresh_token") {
+              return new Response(null, { status: 401 })
+            }
+
+            return jsonResponse({
+              id_token: createTestJwt({
+                chatgpt_account_id: "account-from-id",
+              }),
+              access_token: createTestJwt({
+                chatgpt_account_id: "account-from-access",
+              }),
+              refresh_token: "next-refresh-token",
+              expires_in: 120,
+            })
+          }
+
+          return new Response(null, { status: 500 })
+        })
+
+        const auth = yield* CodexAuth.make.pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+        )
+
+        const token = yield* auth.get
+
+        assert.strictEqual(token.refresh, "next-refresh-token")
+        assert.strictEqual(
+          Option.getOrUndefined(token.accountId),
+          "account-from-id",
+        )
+
+        const stored = yield* Effect.orDie(tokenStore.get(STORE_TOKEN_KEY))
+        assert.strictEqual(Option.isSome(stored), true)
+        if (Option.isSome(stored)) {
+          assert.strictEqual(stored.value.refresh, "next-refresh-token")
+        }
+
+        const seenRequests = yield* Ref.get(requests)
+        assert.strictEqual(seenRequests.length, 4)
+        assert.strictEqual(seenRequests[0]?.url, `${ISSUER}/oauth/token`)
+        assert.strictEqual(
+          new URLSearchParams(getBody(seenRequests[0]!)).get("grant_type"),
+          "refresh_token",
+        )
+        assert.strictEqual(
+          new URLSearchParams(getBody(seenRequests[3]!)).get("grant_type"),
+          "authorization_code",
+        )
+      }).pipe(Effect.provide(KeyValueStore.layerMemory)),
+  )
+
+  it.effect("serializes concurrent get calls behind one refresh", () =>
+    Effect.gen(function* () {
+      const kvs = yield* KeyValueStore.KeyValueStore
+      const tokenStore = toTokenStore(kvs)
+      yield* Effect.orDie(
+        tokenStore.set(
+          STORE_TOKEN_KEY,
+          new TokenData({
+            access: "expired-access-token",
+            refresh: "refresh-token",
+            expires: Date.now() - 60_000,
+            accountId: Option.none(),
+          }),
+        ),
+      )
+
+      const refreshStarted = yield* Deferred.make<void>()
+      const releaseRefresh = yield* Deferred.make<void>()
+      const { attempts, client } = yield* makeEffectClient((request) => {
+        if (request.url !== `${ISSUER}/oauth/token`) {
+          return Effect.succeed(new Response(null, { status: 500 }))
+        }
+
+        const body = new URLSearchParams(getBody(request))
+        if (body.get("grant_type") !== "refresh_token") {
+          return Effect.succeed(new Response(null, { status: 500 }))
+        }
+
+        return Effect.gen(function* () {
+          yield* Deferred.succeed(refreshStarted, void 0)
+          yield* Deferred.await(releaseRefresh)
+          return jsonResponse({
+            access_token: createTestJwt({
+              chatgpt_account_id: "fresh-account",
+            }),
+            refresh_token: "fresh-refresh-token",
+            expires_in: 120,
+          })
+        })
+      })
+
+      const auth = yield* CodexAuth.make.pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+      )
+
+      const firstFiber = yield* auth.get.pipe(
+        Effect.forkChild({ startImmediately: true }),
+      )
+      yield* Deferred.await(refreshStarted)
+
+      const secondFiber = yield* auth.get.pipe(
+        Effect.forkChild({ startImmediately: true }),
+      )
+      yield* Effect.yieldNow
+
+      assert.strictEqual(yield* Ref.get(attempts), 1)
+
+      yield* Deferred.succeed(releaseRefresh, void 0)
+
+      const first = yield* Fiber.join(firstFiber)
+      const second = yield* Fiber.join(secondFiber)
+
+      assert.strictEqual(yield* Ref.get(attempts), 1)
+      assert.strictEqual(first.refresh, "fresh-refresh-token")
+      assert.strictEqual(second.refresh, "fresh-refresh-token")
+      assert.strictEqual(
+        Option.getOrUndefined(first.accountId),
+        "fresh-account",
+      )
+      assert.strictEqual(
+        Option.getOrUndefined(second.accountId),
+        "fresh-account",
+      )
+    }).pipe(Effect.provide(KeyValueStore.layerMemory)),
+  )
+
+  it.effect(
+    "returns device flow failures after refresh fallback and clears the cached token",
+    () =>
+      Effect.gen(function* () {
+        const kvs = yield* KeyValueStore.KeyValueStore
+        const tokenStore = toTokenStore(kvs)
+        yield* Effect.orDie(
+          tokenStore.set(
+            STORE_TOKEN_KEY,
+            new TokenData({
+              access: "expired-access-token",
+              refresh: "refresh-token",
+              expires: Date.now() - 60_000,
+              accountId: Option.none(),
+            }),
+          ),
+        )
+
+        const { client, requests } = yield* makeClient((request) => {
+          if (request.url === `${ISSUER}/oauth/token`) {
+            const body = new URLSearchParams(getBody(request))
+            if (body.get("grant_type") === "refresh_token") {
+              return new Response(null, { status: 401 })
+            }
+          }
+
+          if (request.url === `${ISSUER}/api/accounts/deviceauth/usercode`) {
+            return new Response(null, { status: 500 })
+          }
+
+          return new Response(null, { status: 500 })
+        })
+
+        const auth = yield* CodexAuth.make.pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+        )
+
+        const firstError = yield* auth.get.pipe(Effect.flip)
+        assert.strictEqual(firstError.reason, "DeviceFlowFailed")
+
+        const storedAfterFirstFailure = yield* Effect.orDie(
+          tokenStore.get(STORE_TOKEN_KEY),
+        )
+        assert.strictEqual(Option.isNone(storedAfterFirstFailure), true)
+
+        const secondError = yield* auth.get.pipe(Effect.flip)
+        assert.strictEqual(secondError.reason, "DeviceFlowFailed")
+
+        const seenRequests = yield* Ref.get(requests)
+        const refreshRequests = seenRequests.filter((request) => {
+          if (request.url !== `${ISSUER}/oauth/token`) {
+            return false
+          }
+
+          return (
+            new URLSearchParams(getBody(request)).get("grant_type") ===
+            "refresh_token"
+          )
+        })
+        const deviceCodeRequests = seenRequests.filter(
+          (request) =>
+            request.url === `${ISSUER}/api/accounts/deviceauth/usercode`,
+        )
+
+        assert.strictEqual(refreshRequests.length, 1)
+        assert.strictEqual(deviceCodeRequests.length, 2)
+      }).pipe(Effect.provide(KeyValueStore.layerMemory)),
+  )
+
+  it.effect(
+    "forces device auth on authenticate and clears cache plus storage on logout",
+    () =>
+      Effect.gen(function* () {
+        const kvs = yield* KeyValueStore.KeyValueStore
+        const tokenStore = toTokenStore(kvs)
+        yield* Effect.orDie(
+          tokenStore.set(
+            STORE_TOKEN_KEY,
+            new TokenData({
+              access: "cached-access-token",
+              refresh: "cached-refresh-token",
+              expires: Date.now() + 600_000,
+              accountId: Option.some("cached-account"),
+            }),
+          ),
+        )
+
+        let deviceFlowCount = 0
+        const { attempts, client } = yield* makeClient((request) => {
+          if (request.url === `${ISSUER}/api/accounts/deviceauth/usercode`) {
+            deviceFlowCount += 1
+            return jsonResponse({
+              device_auth_id: `device-auth-${deviceFlowCount}`,
+              user_code: `CODE-${deviceFlowCount}`,
+              interval: "1",
+            })
+          }
+
+          if (request.url === `${ISSUER}/api/accounts/deviceauth/token`) {
+            return jsonResponse({
+              authorization_code: `authorization-code-${deviceFlowCount}`,
+              code_verifier: `code-verifier-${deviceFlowCount}`,
+            })
+          }
+
+          if (request.url === `${ISSUER}/oauth/token`) {
+            return jsonResponse({
+              access_token: createTestJwt({
+                chatgpt_account_id: `device-account-${deviceFlowCount}`,
+              }),
+              refresh_token: `device-refresh-${deviceFlowCount}`,
+              expires_in: 120,
+            })
+          }
+
+          return new Response(null, { status: 500 })
+        })
+
+        const auth = yield* CodexAuth.make.pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+        )
+
+        const cachedToken = yield* auth.get
+        assert.strictEqual(cachedToken.refresh, "cached-refresh-token")
+        assert.strictEqual(yield* Ref.get(attempts), 0)
+
+        const authenticated = yield* auth.authenticate
+        assert.strictEqual(authenticated.refresh, "device-refresh-1")
+        assert.strictEqual(
+          Option.getOrUndefined(authenticated.accountId),
+          "device-account-1",
+        )
+        assert.strictEqual(yield* Ref.get(attempts), 3)
+
+        yield* auth.logout
+        const storedAfterLogout = yield* Effect.orDie(
+          tokenStore.get(STORE_TOKEN_KEY),
+        )
+        assert.strictEqual(Option.isNone(storedAfterLogout), true)
+
+        const tokenAfterLogout = yield* auth.get
+        assert.strictEqual(tokenAfterLogout.refresh, "device-refresh-2")
+        assert.strictEqual(
+          Option.getOrUndefined(tokenAfterLogout.accountId),
+          "device-account-2",
+        )
+        assert.strictEqual(yield* Ref.get(attempts), 6)
+      }).pipe(Effect.provide(KeyValueStore.layerMemory)),
+  )
+
   it("re-exports the public Codex auth surface without storage helpers", () => {
     assert.strictEqual(PublicApi.CLIENT_ID, CLIENT_ID)
+    assert.strictEqual(PublicApi.CodexAuth, CodexAuth)
     assert.strictEqual(PublicApi.CODEX_API_BASE, CODEX_API_BASE)
     assert.strictEqual(PublicApi.ISSUER, ISSUER)
     assert.strictEqual(

--- a/src/CodexAuth.test.ts
+++ b/src/CodexAuth.test.ts
@@ -688,6 +688,63 @@ describe("CodexAuth", () => {
       }).pipe(Effect.provide(KeyValueStore.layerMemory)),
   )
 
+  it.effect("clears corrupted persisted tokens before re-authenticating", () =>
+    Effect.gen(function* () {
+      const kvs = yield* KeyValueStore.KeyValueStore
+      yield* Effect.orDie(
+        kvs.set(`${STORE_PREFIX}${STORE_TOKEN_KEY}`, "not-json"),
+      )
+
+      const { attempts, client } = yield* makeClient((request) => {
+        if (request.url === `${ISSUER}/api/accounts/deviceauth/usercode`) {
+          return jsonResponse({
+            device_auth_id: "device-auth-id",
+            user_code: "ABCD-EFGH",
+            interval: "1",
+          })
+        }
+
+        if (request.url === `${ISSUER}/api/accounts/deviceauth/token`) {
+          return jsonResponse({
+            authorization_code: "authorization-code",
+            code_verifier: "code-verifier",
+          })
+        }
+
+        if (request.url === `${ISSUER}/oauth/token`) {
+          return jsonResponse({
+            access_token: createTestJwt({
+              chatgpt_account_id: "fresh-account",
+            }),
+            refresh_token: "fresh-refresh-token",
+            expires_in: 120,
+          })
+        }
+
+        return new Response(null, { status: 500 })
+      })
+
+      const auth = yield* CodexAuth.make.pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+      )
+
+      assert.strictEqual(
+        yield* Effect.orDie(kvs.get(`${STORE_PREFIX}${STORE_TOKEN_KEY}`)),
+        undefined,
+      )
+      assert.strictEqual(yield* Ref.get(attempts), 0)
+
+      const token = yield* auth.get
+
+      assert.strictEqual(token.refresh, "fresh-refresh-token")
+      assert.strictEqual(
+        Option.getOrUndefined(token.accountId),
+        "fresh-account",
+      )
+      assert.strictEqual(yield* Ref.get(attempts), 3)
+    }).pipe(Effect.provide(KeyValueStore.layerMemory)),
+  )
+
   it.effect("serializes concurrent get calls behind one refresh", () =>
     Effect.gen(function* () {
       const kvs = yield* KeyValueStore.KeyValueStore

--- a/src/CodexAuth.ts
+++ b/src/CodexAuth.ts
@@ -404,7 +404,17 @@ export class CodexAuth extends ServiceMap.Service<CodexAuth>()(
       const httpClient = yield* HttpClient.HttpClient
       const semaphore = Semaphore.makeUnsafe(1)
 
-      let currentToken = yield* Effect.orDie(tokenStore.get(STORE_TOKEN_KEY))
+      let currentToken = yield* tokenStore.get(STORE_TOKEN_KEY).pipe(
+        Effect.catchTag("SchemaError", (error) =>
+          Console.warn(
+            `Failed to decode persisted Codex token, clearing it: ${error.message}`,
+          ).pipe(
+            Effect.andThen(tokenStore.remove(STORE_TOKEN_KEY)),
+            Effect.as(Option.none()),
+          ),
+        ),
+        Effect.orDie,
+      )
 
       const withHttpClient = <A, E>(
         effect: Effect.Effect<A, E, HttpClient.HttpClient>,

--- a/src/CodexAuth.ts
+++ b/src/CodexAuth.ts
@@ -1,4 +1,14 @@
-import { Effect, Encoding, Option, Result, Schema } from "effect"
+import {
+  Console,
+  Effect,
+  Encoding,
+  Layer,
+  Option,
+  Result,
+  Schema,
+  Semaphore,
+  ServiceMap,
+} from "effect"
 import {
   HttpClient,
   HttpClientRequest,
@@ -18,6 +28,7 @@ const DEVICE_CODE_URL = `${ISSUER}/api/accounts/deviceauth/usercode`
 const DEVICE_TOKEN_URL = `${ISSUER}/api/accounts/deviceauth/token`
 const TOKEN_URL = `${ISSUER}/oauth/token`
 const DEVICE_REDIRECT_URI = `${ISSUER}/deviceauth/callback`
+const DEVICE_VERIFICATION_URL = `${ISSUER}/codex/device`
 const DEFAULT_DEVICE_POLL_INTERVAL_SECONDS = 5
 const DEFAULT_TOKEN_EXPIRY_SECONDS = 3600
 
@@ -384,3 +395,97 @@ export const toCodexAuthKeyValueStore = (store: KeyValueStore.KeyValueStore) =>
 
 export const toTokenStore = (store: KeyValueStore.KeyValueStore) =>
   KeyValueStore.toSchemaStore(toCodexAuthKeyValueStore(store), TokenData)
+
+export class CodexAuth extends ServiceMap.Service<CodexAuth>()(
+  "clanka/CodexAuth",
+  {
+    make: Effect.gen(function* () {
+      const tokenStore = toTokenStore(yield* KeyValueStore.KeyValueStore)
+      const httpClient = yield* HttpClient.HttpClient
+      const semaphore = Semaphore.makeUnsafe(1)
+
+      let currentToken = yield* Effect.orDie(tokenStore.get(STORE_TOKEN_KEY))
+
+      const withHttpClient = <A, E>(
+        effect: Effect.Effect<A, E, HttpClient.HttpClient>,
+      ): Effect.Effect<A, E> =>
+        Effect.provideService(effect, HttpClient.HttpClient, httpClient)
+
+      const saveToken = (token: TokenData) =>
+        Effect.orDie(tokenStore.set(STORE_TOKEN_KEY, token)).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              currentToken = Option.some(token)
+            }),
+          ),
+          Effect.as(token),
+        )
+
+      const clearToken = Effect.orDie(tokenStore.remove(STORE_TOKEN_KEY)).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            currentToken = Option.none()
+          }),
+        ),
+      )
+
+      const authenticateWithDeviceFlow = Effect.gen(function* () {
+        const deviceCode = yield* withHttpClient(requestDeviceCode())
+        yield* Console.log(
+          `Open ${DEVICE_VERIFICATION_URL} and enter code: ${deviceCode.userCode}`,
+        )
+        const authorization = yield* withHttpClient(
+          pollAuthorization(deviceCode),
+        )
+        return yield* withHttpClient(exchangeAuthorizationCode(authorization))
+      })
+
+      const authenticateNoLock = Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          const token = yield* restore(authenticateWithDeviceFlow)
+          return yield* saveToken(token)
+        }),
+      )
+
+      const getNoLock = Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          if (Option.isSome(currentToken) && !currentToken.value.isExpired()) {
+            return currentToken.value
+          }
+
+          if (Option.isNone(currentToken)) {
+            const token = yield* restore(authenticateWithDeviceFlow)
+            return yield* saveToken(token)
+          }
+
+          const refreshedToken = yield* restore(
+            withHttpClient(refreshToken(currentToken.value.refresh)).pipe(
+              Effect.tapError((error) =>
+                Console.warn(
+                  `Codex token refresh failed, falling back to device auth: ${error.message}`,
+                ),
+              ),
+              Effect.option,
+            ),
+          )
+
+          if (Option.isSome(refreshedToken)) {
+            return yield* saveToken(refreshedToken.value)
+          }
+
+          yield* clearToken
+          const token = yield* restore(authenticateWithDeviceFlow)
+          return yield* saveToken(token)
+        }),
+      )
+
+      return {
+        get: semaphore.withPermit(getNoLock),
+        authenticate: semaphore.withPermit(authenticateNoLock),
+        logout: semaphore.withPermit(Effect.uninterruptible(clearToken)),
+      } as const
+    }),
+  },
+) {
+  static readonly layer = Layer.effect(this, this.make)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export {
   CLIENT_ID,
+  CodexAuth,
   CODEX_API_BASE,
   CodexAuthError,
   ISSUER,


### PR DESCRIPTION
## Summary
- add the `CodexAuth` service layer with cached token loading, semaphore-guarded `get` / `authenticate` / `logout`, refresh handling, and device-flow fallback persistence
- expand `src/CodexAuth.test.ts` with service-level coverage for refresh fallback, concurrent refresh serialization, terminal device-flow errors, and logout/authenticate cache behavior
- re-export `CodexAuth` from `src/index.ts` so consumers can provide the service layer directly