### PR TITLE
TIM-687: add applyPatch tool to AgentTools

### DIFF
--- a/src/AgentTools.test.ts
+++ b/src/AgentTools.test.ts
@@ -1,0 +1,86 @@
+import { NodeServices } from "@effect/platform-node"
+import { Deferred, Effect, Layer } from "effect"
+import { Tool } from "effect/unstable/ai"
+import * as Fs from "node:fs/promises"
+import * as Os from "node:os"
+import * as Path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import {
+  AgentToolHandlers,
+  AgentTools,
+  CurrentDirectory,
+  TaskCompleteDeferred,
+} from "./AgentTools.ts"
+
+const dirs = Array<string>()
+
+const makeDir = async () => {
+  const dir = await Fs.mkdtemp(Path.join(Os.tmpdir(), "clanka-agent-tools-"))
+  dirs.push(dir)
+  return dir
+}
+
+const call = (
+  dir: string,
+  name: keyof typeof AgentTools.tools,
+  params: unknown,
+): Promise<string> =>
+  Effect.runPromise(
+    Effect.provide(
+      Effect.gen(function* () {
+        const all = yield* Effect.services()
+        const tool = AgentTools.tools[name]
+        const handler = all.mapUnsafe.get(tool.id) as Tool.Handler<string>
+        return (yield* handler
+          .handler(params, {})
+          .pipe(Effect.provideServices(handler.services))) as string
+      }),
+      AgentToolHandlers.pipe(
+        Layer.provideMerge(NodeServices.layer),
+        Layer.provideMerge(Layer.succeed(CurrentDirectory, dir)),
+        Layer.provideMerge(
+          Layer.effect(TaskCompleteDeferred, Deferred.make<string>()),
+        ),
+      ),
+    ),
+  )
+
+afterEach(async () => {
+  await Promise.all(
+    dirs.splice(0).map((dir) => Fs.rm(dir, { recursive: true, force: true })),
+  )
+})
+
+describe("AgentTools", () => {
+  it("includes applyPatch", () => {
+    expect(AgentTools.tools).toHaveProperty("applyPatch")
+  })
+
+  it("applies patches relative to the current directory", async () => {
+    const dir = await makeDir()
+    const file = Path.join(dir, "sample.txt")
+    await Fs.writeFile(file, "before\n", "utf8")
+
+    const result = await call(dir, "applyPatch", {
+      path: "sample.txt",
+      patchText: "@@\n-before\n+after",
+    })
+
+    expect(result).toContain("M sample.txt")
+    expect(await Fs.readFile(file, "utf8")).toBe("after\n")
+  })
+
+  it("reads files relative to the current directory", async () => {
+    const dir = await makeDir()
+    const file = Path.join(dir, "nested", "note.txt")
+    await Fs.mkdir(Path.dirname(file), { recursive: true })
+    await Fs.writeFile(file, "hello\nworld\n", "utf8")
+
+    const result = await call(dir, "readFile", {
+      path: "nested/note.txt",
+      startLine: 2,
+    })
+
+    expect(result).toBe("world")
+  })
+})

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -12,6 +12,8 @@ import { Tool, Toolkit } from "effect/unstable/ai"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import * as Glob from "glob"
 import * as Rg from "@vscode/ripgrep"
+import * as Path from "node:path"
+import { patchContent } from "./ApplyPatch.ts"
 
 export const AgentTools = Toolkit.make(
   Tool.make("readFile", {
@@ -51,6 +53,18 @@ export const AgentTools = Toolkit.make(
     }),
     success: Schema.String,
   }),
+  Tool.make("applyPatch", {
+    description:
+      "Apply an opencode-style patch to a single file using raw @@ hunks or a wrapped patch block.",
+    parameters: Schema.Struct({
+      path: Schema.String,
+      patchText: Schema.String.annotate({
+        documentation:
+          "Use raw @@ hunks for the target file, or a full *** Begin Patch block with one *** Update File section.",
+      }),
+    }),
+    success: Schema.String,
+  }),
   Tool.make("taskComplete", {
     description:
       "Call this when you have fully completed the user's task, completely ending the session",
@@ -76,11 +90,12 @@ export const AgentToolHandlers = AgentTools.toLayer(
     const cwd = yield* CurrentDirectory
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const fs = yield* FileSystem.FileSystem
+    const resolve = (path: string) => Path.resolve(cwd, path)
 
     return AgentTools.of({
       readFile: Effect.fn("AgentTools.readFile")((options) => {
         let stream = pipe(
-          fs.stream(options.path),
+          fs.stream(resolve(options.path)),
           Stream.decodeText,
           Stream.splitLines,
         )
@@ -135,6 +150,24 @@ export const AgentToolHandlers = AgentTools.toLayer(
           stdin: "ignore",
         })
         return yield* spawner.string(cmd).pipe(Effect.orDie)
+      }),
+      applyPatch: Effect.fn("AgentTools.applyPatch")(function* (options) {
+        const file = resolve(options.path)
+        const input = yield* fs.readFileString(file).pipe(
+          Effect.mapError(
+            () =>
+              new Error(
+                `applyPatch verification failed: Failed to read file to update: ${file}`,
+              ),
+          ),
+          Effect.orDie,
+        )
+        const next = yield* Effect.sync(() =>
+          patchContent(file, input, options.patchText),
+        ).pipe(Effect.orDie)
+        yield* fs.writeFileString(file, next).pipe(Effect.orDie)
+        const path = Path.relative(cwd, file).replaceAll("\\", "/")
+        return `Success. Updated the following files:\nM ${path}`
       }),
       taskComplete: Effect.fn("AgentTools.taskComplete")((message) =>
         Deferred.succeed(deferred, message),

--- a/src/ApplyPatch.test.ts
+++ b/src/ApplyPatch.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { patchContent } from "./ApplyPatch.ts"
+
+describe("patchContent", () => {
+  it("applies raw hunks", () => {
+    expect(
+      patchContent("sample.txt", "line1\nline2\n", "@@\n-line2\n+changed"),
+    ).toBe("line1\nchanged\n")
+  })
+
+  it("parses wrapped single-file patches", () => {
+    expect(
+      patchContent(
+        "sample.txt",
+        "alpha\nomega\n",
+        "*** Begin Patch\n*** Update File: ignored.txt\n@@\n alpha\n+beta\n omega\n*** End Patch",
+      ),
+    ).toBe("alpha\nbeta\nomega\n")
+  })
+
+  it("matches EOF hunks from the end of the file", () => {
+    expect(
+      patchContent(
+        "tail.txt",
+        "start\nmarker\nmiddle\nmarker\nend\n",
+        "@@\n-marker\n-end\n+marker-changed\n+end\n*** End of File",
+      ),
+    ).toBe("start\nmarker\nmiddle\nmarker-changed\nend\n")
+  })
+
+  it("preserves CRLF files", () => {
+    expect(patchContent("crlf.txt", "old\r\n", "@@\n-old\n+new")).toBe(
+      "new\r\n",
+    )
+  })
+
+  it("rejects multi-file wrapped patches", () => {
+    expect(() =>
+      patchContent(
+        "sample.txt",
+        "line1\nline2\n",
+        "*** Begin Patch\n*** Update File: a.txt\n@@\n-line2\n+changed\n*** Update File: b.txt\n@@\n-old\n+new\n*** End Patch",
+      ),
+    ).toThrow("only one update file section is supported")
+  })
+})

--- a/src/ApplyPatch.ts
+++ b/src/ApplyPatch.ts
@@ -1,0 +1,307 @@
+type Chunk = {
+  readonly old: ReadonlyArray<string>
+  readonly next: ReadonlyArray<string>
+  readonly ctx?: string
+  readonly eof?: boolean
+}
+
+const BEGIN = "*** Begin Patch"
+const END = "*** End Patch"
+
+const stripHeredoc = (input: string): string => {
+  const match = input.match(
+    /^(?:cat\s+)?<<['"]?(\w+)['"]?\s*\n([\s\S]*?)\n\1\s*$/,
+  )
+  return match?.[2] ?? input
+}
+
+const normalize = (input: string): string =>
+  stripHeredoc(input.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim())
+
+const fail = (message: string): never => {
+  throw new Error(`applyPatch verification failed: ${message}`)
+}
+
+const parseChunks = (
+  lines: ReadonlyArray<string>,
+  start: number,
+  end = lines.length,
+) => {
+  const chunks = Array<Chunk>()
+  let i = start
+
+  while (i < end) {
+    const line = lines[i]!
+    if (line.startsWith("***")) {
+      break
+    }
+    if (!line.startsWith("@@")) {
+      i++
+      continue
+    }
+
+    const ctx = line.slice(2).trim()
+    const old = Array<string>()
+    const next = Array<string>()
+    let eof = false
+    i++
+
+    while (i < end) {
+      const line = lines[i]!
+      if (line.startsWith("@@") || line.startsWith("***")) {
+        break
+      }
+      if (line === "*** End of File") {
+        eof = true
+        i++
+        break
+      }
+      if (line.startsWith(" ")) {
+        const text = line.slice(1)
+        old.push(text)
+        next.push(text)
+      } else if (line.startsWith("-")) {
+        old.push(line.slice(1))
+      } else if (line.startsWith("+")) {
+        next.push(line.slice(1))
+      }
+      i++
+    }
+
+    chunks.push({
+      old,
+      next,
+      ...(ctx.length > 0 ? { ctx } : {}),
+      ...(eof ? { eof: true } : {}),
+    })
+  }
+
+  return {
+    chunks,
+    next: i,
+  }
+}
+
+const parseWrapped = (text: string): ReadonlyArray<Chunk> => {
+  const lines = text.split("\n")
+  const begin = lines.findIndex((line) => line.trim() === BEGIN)
+  const end = lines.findIndex((line) => line.trim() === END)
+  if (begin === -1 || end === -1 || begin >= end) {
+    fail("Invalid patch format: missing Begin/End markers")
+  }
+
+  let i = begin + 1
+  while (i < end && lines[i]!.trim() === "") {
+    i++
+  }
+  if (i === end) {
+    throw new Error("patch rejected: empty patch")
+  }
+  if (!lines[i]!.startsWith("*** Update File:")) {
+    fail("only single-file update patches are supported")
+  }
+
+  i++
+  if (i < end && lines[i]!.startsWith("*** Move to:")) {
+    fail("move patches are not supported")
+  }
+
+  const parsed = parseChunks(lines, i, end)
+  if (parsed.chunks.length === 0) {
+    fail("no hunks found")
+  }
+
+  i = parsed.next
+  while (i < end && lines[i]!.trim() === "") {
+    i++
+  }
+  if (i !== end) {
+    fail("only one update file section is supported")
+  }
+
+  return parsed.chunks
+}
+
+const parse = (input: string): ReadonlyArray<Chunk> => {
+  const text = normalize(input)
+  if (text.length === 0) {
+    throw new Error("patchText is required")
+  }
+  if (text === `${BEGIN}\n${END}`) {
+    throw new Error("patch rejected: empty patch")
+  }
+
+  if (text.includes(BEGIN)) {
+    return parseWrapped(text)
+  }
+
+  const parsed = parseChunks(text.split("\n"), 0)
+  if (parsed.chunks.length === 0) {
+    fail("no hunks found")
+  }
+  return parsed.chunks
+}
+
+const normalizeUnicode = (line: string): string =>
+  line
+    .replace(/[\u2018\u2019\u201A\u201B]/g, "'")
+    .replace(/[\u201C\u201D\u201E\u201F]/g, '"')
+    .replace(/[\u2010\u2011\u2012\u2013\u2014\u2015]/g, "-")
+    .replace(/\u2026/g, "...")
+    .replace(/\u00A0/g, " ")
+
+const match = (
+  lines: ReadonlyArray<string>,
+  part: ReadonlyArray<string>,
+  from: number,
+  same: (left: string, right: string) => boolean,
+  eof: boolean,
+): number => {
+  if (eof) {
+    const last = lines.length - part.length
+    if (last >= from) {
+      let ok = true
+      for (let i = 0; i < part.length; i++) {
+        if (!same(lines[last + i]!, part[i]!)) {
+          ok = false
+          break
+        }
+      }
+      if (ok) {
+        return last
+      }
+    }
+  }
+
+  for (let i = from; i <= lines.length - part.length; i++) {
+    let ok = true
+    for (let j = 0; j < part.length; j++) {
+      if (!same(lines[i + j]!, part[j]!)) {
+        ok = false
+        break
+      }
+    }
+    if (ok) {
+      return i
+    }
+  }
+
+  return -1
+}
+
+const seek = (
+  lines: ReadonlyArray<string>,
+  part: ReadonlyArray<string>,
+  from: number,
+  eof = false,
+): number => {
+  if (part.length === 0) {
+    return -1
+  }
+
+  const exact = match(lines, part, from, (left, right) => left === right, eof)
+  if (exact !== -1) {
+    return exact
+  }
+
+  const rstrip = match(
+    lines,
+    part,
+    from,
+    (left, right) => left.trimEnd() === right.trimEnd(),
+    eof,
+  )
+  if (rstrip !== -1) {
+    return rstrip
+  }
+
+  const trim = match(
+    lines,
+    part,
+    from,
+    (left, right) => left.trim() === right.trim(),
+    eof,
+  )
+  if (trim !== -1) {
+    return trim
+  }
+
+  return match(
+    lines,
+    part,
+    from,
+    (left, right) =>
+      normalizeUnicode(left.trim()) === normalizeUnicode(right.trim()),
+    eof,
+  )
+}
+
+const compute = (
+  file: string,
+  lines: ReadonlyArray<string>,
+  chunks: ReadonlyArray<Chunk>,
+): Array<readonly [number, number, ReadonlyArray<string>]> => {
+  const out = Array<readonly [number, number, ReadonlyArray<string>]>()
+  let from = 0
+
+  for (const chunk of chunks) {
+    if (chunk.ctx) {
+      const at = seek(lines, [chunk.ctx], from)
+      if (at === -1) {
+        fail(`Failed to find context '${chunk.ctx}' in ${file}`)
+      }
+      from = at + 1
+    }
+
+    if (chunk.old.length === 0) {
+      out.push([lines.length, 0, chunk.next])
+      continue
+    }
+
+    let old = chunk.old
+    let next = chunk.next
+    let at = seek(lines, old, from, chunk.eof === true)
+    if (at === -1 && old.at(-1) === "") {
+      old = old.slice(0, -1)
+      next = next.at(-1) === "" ? next.slice(0, -1) : next
+      at = seek(lines, old, from, chunk.eof === true)
+    }
+    if (at === -1) {
+      fail(`Failed to find expected lines in ${file}:\n${chunk.old.join("\n")}`)
+    }
+
+    out.push([at, old.length, next])
+    from = at + old.length
+  }
+
+  out.sort((left, right) => left[0] - right[0])
+  return out
+}
+
+export const patchContent = (
+  file: string,
+  input: string,
+  patchText: string,
+): string => {
+  const eol = input.includes("\r\n") ? "\r\n" : "\n"
+  const lines = input.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n")
+  if (lines.at(-1) === "") {
+    lines.pop()
+  }
+
+  const out = [...lines]
+  for (const [at, size, next] of compute(
+    file,
+    lines,
+    parse(patchText),
+  ).reverse()) {
+    out.splice(at, size, ...next)
+  }
+
+  if (out.at(-1) !== "") {
+    out.push("")
+  }
+
+  const text = out.join("\n")
+  return eol === "\r\n" ? text.replace(/\n/g, "\r\n") : text
+}


### PR DESCRIPTION
## Summary
- add an `applyPatch` AgentTools entry backed by a single-file patch engine that accepts raw `@@` hunks or wrapped `*** Begin Patch` blocks
- resolve file tool paths against `CurrentDirectory` so `readFile` and patch writes behave consistently
- add parser coverage and AgentTools integration tests for the new editing flow

## Testing
- pnpm check
- pnpm test