### PR TITLE
TIM-685: compose Codex auth-aware client layers

### DIFF
--- a/src/Codex.test.ts
+++ b/src/Codex.test.ts
@@ -1,0 +1,224 @@
+import { Generated, OpenAiClient } from "@effect/ai-openai"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Encoding, Layer, Option, Ref } from "effect"
+import { LanguageModel } from "effect/unstable/ai"
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http"
+import { KeyValueStore } from "effect/unstable/persistence"
+import * as Codex from "./Codex.ts"
+import { CodexAuth, ISSUER, TokenData } from "./CodexAuth.ts"
+import * as PublicApi from "./index.ts"
+
+const DEFAULT_MODEL = "gpt-5.3-codex"
+
+const createJwt = (payload: string): string =>
+  `${Encoding.encodeBase64Url(JSON.stringify({ alg: "none" }))}.${Encoding.encodeBase64Url(payload)}.sig`
+
+const createTestJwt = (payload: Record<string, unknown>): string =>
+  createJwt(JSON.stringify(payload))
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  })
+
+const getBody = (request: HttpClientRequest.HttpClientRequest): string => {
+  if (request.body._tag !== "Uint8Array") {
+    throw new Error("Expected request body to be a Uint8Array payload")
+  }
+
+  return new TextDecoder().decode(request.body.body)
+}
+
+const makeClient = Effect.fn("makeClient")(function* (
+  handler: (
+    request: HttpClientRequest.HttpClientRequest,
+    attempt: number,
+  ) => Response,
+) {
+  const attempts = yield* Ref.make(0)
+  const requests = yield* Ref.make<Array<HttpClientRequest.HttpClientRequest>>(
+    [],
+  )
+  const client = HttpClient.make((request) =>
+    Effect.gen(function* () {
+      const attempt = yield* Ref.updateAndGet(attempts, (count) => count + 1)
+      yield* Ref.update(requests, (current) => [...current, request])
+      return HttpClientResponse.fromWeb(request, handler(request, attempt))
+    }),
+  )
+
+  return {
+    attempts,
+    client,
+    requests,
+  } as const
+})
+
+const makeResponse = (
+  overrides: Partial<Generated.Response> = {},
+): Generated.Response => ({
+  id: "resp_test123",
+  object: "response",
+  created_at: Math.floor(Date.now() / 1_000),
+  model: DEFAULT_MODEL,
+  status: "completed",
+  output: [],
+  metadata: null,
+  temperature: null,
+  top_p: null,
+  tools: [],
+  tool_choice: "auto",
+  error: null,
+  incomplete_details: null,
+  instructions: null,
+  parallel_tool_calls: false,
+  ...overrides,
+})
+
+describe("Codex", () => {
+  it.effect(
+    "injects bearer and account headers through CodexAuth.layerClient",
+    () =>
+      Effect.gen(function* () {
+        const { client, requests } = yield* makeClient(
+          () => new Response(null, { status: 204 }),
+        )
+
+        const layer = CodexAuth.layerClient.pipe(
+          Layer.provide(
+            Layer.succeed(
+              CodexAuth,
+              CodexAuth.of({
+                get: Effect.succeed(
+                  new TokenData({
+                    access: "access-token",
+                    refresh: "refresh-token",
+                    expires: Date.now() + 60_000,
+                    accountId: Option.some("account-123"),
+                  }),
+                ),
+                authenticate: Effect.die(
+                  new Error("unexpected authenticate call"),
+                ),
+                logout: Effect.succeed(void 0),
+              }),
+            ),
+          ),
+          Layer.provide(Layer.succeed(HttpClient.HttpClient, client)),
+        )
+
+        yield* HttpClientRequest.get("https://example.com/test").pipe(
+          HttpClient.execute,
+          Effect.provide(layer),
+        )
+
+        const request = (yield* Ref.get(requests))[0]
+        assert.notStrictEqual(request, undefined)
+        if (request === undefined) {
+          return
+        }
+
+        assert.strictEqual(
+          request.headers["authorization"],
+          "Bearer access-token",
+        )
+        assert.strictEqual(request.headers["chatgpt-account-id"], "account-123")
+      }),
+  )
+
+  it.effect("provides OpenAiClient and LanguageModel through Codex.layer", () =>
+    Effect.gen(function* () {
+      const accessToken = createTestJwt({ chatgpt_account_id: "account-123" })
+      const { attempts, client, requests } = yield* makeClient((request) => {
+        if (request.url === `${ISSUER}/api/accounts/deviceauth/usercode`) {
+          return jsonResponse({
+            device_auth_id: "device-auth-id",
+            user_code: "ABCD-EFGH",
+            interval: "1",
+          })
+        }
+
+        if (request.url === `${ISSUER}/api/accounts/deviceauth/token`) {
+          return jsonResponse({
+            authorization_code: "authorization-code",
+            code_verifier: "code-verifier",
+          })
+        }
+
+        if (request.url === `${ISSUER}/oauth/token`) {
+          return jsonResponse({
+            access_token: accessToken,
+            refresh_token: "refresh-token",
+            expires_in: 120,
+          })
+        }
+
+        if (request.url === "https://chatgpt.com/backend-api/codex/responses") {
+          return jsonResponse(makeResponse())
+        }
+
+        return new Response(null, { status: 500 })
+      })
+
+      const program = Effect.gen(function* () {
+        const openAi = yield* OpenAiClient.OpenAiClient
+        const languageModel = yield* LanguageModel.LanguageModel
+        const response = yield* LanguageModel.generateText({ prompt: "test" })
+
+        assert.notStrictEqual(openAi.client, undefined)
+        assert.notStrictEqual(languageModel, undefined)
+
+        const metadata = response.content.find(
+          (part) => part.type === "response-metadata",
+        )
+        assert.strictEqual(metadata?.modelId, DEFAULT_MODEL)
+
+        const seenRequests = yield* Ref.get(requests)
+        assert.strictEqual(yield* Ref.get(attempts), 4)
+        assert.strictEqual(seenRequests.length, 4)
+        assert.strictEqual(
+          seenRequests[3]?.url,
+          "https://chatgpt.com/backend-api/codex/responses",
+        )
+
+        const responseRequest = seenRequests[3]
+        assert.notStrictEqual(responseRequest, undefined)
+        if (responseRequest === undefined) {
+          return
+        }
+
+        assert.strictEqual(
+          responseRequest.headers["authorization"],
+          `Bearer ${accessToken}`,
+        )
+        assert.strictEqual(
+          responseRequest.headers["chatgpt-account-id"],
+          "account-123",
+        )
+        assert.strictEqual(seenRequests[0]?.headers["authorization"], undefined)
+        assert.strictEqual(
+          JSON.parse(getBody(responseRequest)).model,
+          DEFAULT_MODEL,
+        )
+      })
+
+      yield* program.pipe(
+        Effect.provide(Codex.layer),
+        Effect.provide(KeyValueStore.layerMemory),
+        Effect.provide(Layer.succeed(HttpClient.HttpClient, client)),
+      )
+    }),
+  )
+
+  it("re-exports the Codex module at the package root", () => {
+    assert.strictEqual(PublicApi.Codex.layer, Codex.layer)
+    assert.strictEqual(PublicApi.Codex.model, Codex.model)
+  })
+})

--- a/src/Codex.test.ts
+++ b/src/Codex.test.ts
@@ -1,6 +1,6 @@
 import { Generated, OpenAiClient } from "@effect/ai-openai"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Encoding, Layer, Option, Ref } from "effect"
+import { Cause, Effect, Encoding, Layer, Option, Ref, Result } from "effect"
 import { LanguageModel } from "effect/unstable/ai"
 import {
   HttpClient,
@@ -9,7 +9,7 @@ import {
 } from "effect/unstable/http"
 import { KeyValueStore } from "effect/unstable/persistence"
 import * as Codex from "./Codex.ts"
-import { CodexAuth, ISSUER, TokenData } from "./CodexAuth.ts"
+import { CodexAuth, CodexAuthError, ISSUER, TokenData } from "./CodexAuth.ts"
 import * as PublicApi from "./index.ts"
 
 const DEFAULT_MODEL = "gpt-5.3-codex"
@@ -133,6 +133,105 @@ describe("Codex", () => {
       }),
   )
 
+  it.effect("omits the account header when CodexAuth has no account id", () =>
+    Effect.gen(function* () {
+      const { client, requests } = yield* makeClient(
+        () => new Response(null, { status: 204 }),
+      )
+
+      const layer = CodexAuth.layerClient.pipe(
+        Layer.provide(
+          Layer.succeed(
+            CodexAuth,
+            CodexAuth.of({
+              get: Effect.succeed(
+                new TokenData({
+                  access: "access-token",
+                  refresh: "refresh-token",
+                  expires: Date.now() + 60_000,
+                  accountId: Option.none(),
+                }),
+              ),
+              authenticate: Effect.die(
+                new Error("unexpected authenticate call"),
+              ),
+              logout: Effect.succeed(void 0),
+            }),
+          ),
+        ),
+        Layer.provide(Layer.succeed(HttpClient.HttpClient, client)),
+      )
+
+      yield* HttpClientRequest.get("https://example.com/test").pipe(
+        HttpClient.execute,
+        Effect.provide(layer),
+      )
+
+      const request = (yield* Ref.get(requests))[0]
+      assert.notStrictEqual(request, undefined)
+      if (request === undefined) {
+        return
+      }
+
+      assert.strictEqual(
+        request.headers["authorization"],
+        "Bearer access-token",
+      )
+      assert.strictEqual(request.headers["chatgpt-account-id"], undefined)
+    }),
+  )
+
+  it.effect("defects with context when auth header injection fails", () =>
+    Effect.gen(function* () {
+      const { client } = yield* makeClient(
+        () => new Response(null, { status: 204 }),
+      )
+      const authError = new CodexAuthError({
+        reason: "DeviceFlowFailed",
+        message: "device flow broke",
+      })
+
+      const layer = CodexAuth.layerClient.pipe(
+        Layer.provide(
+          Layer.succeed(
+            CodexAuth,
+            CodexAuth.of({
+              get: Effect.fail(authError),
+              authenticate: Effect.die(
+                new Error("unexpected authenticate call"),
+              ),
+              logout: Effect.succeed(void 0),
+            }),
+          ),
+        ),
+        Layer.provide(Layer.succeed(HttpClient.HttpClient, client)),
+      )
+
+      const cause = yield* HttpClientRequest.get(
+        "https://example.com/test",
+      ).pipe(
+        HttpClient.execute,
+        Effect.provide(layer),
+        Effect.sandbox,
+        Effect.flip,
+      )
+
+      assert.strictEqual(Cause.hasDies(cause), true)
+
+      const defect = Result.getOrUndefined(Cause.findDefect(cause))
+      assert.notStrictEqual(defect, undefined)
+      if (!(defect instanceof Error)) {
+        assert.fail("Expected the defect to be an Error")
+      }
+
+      assert.strictEqual(
+        defect.message,
+        "Failed to inject Codex auth headers for GET https://example.com/test: device flow broke",
+      )
+      assert.strictEqual(defect.cause, authError)
+    }),
+  )
+
   it.effect("provides OpenAiClient and LanguageModel through Codex.layer", () =>
     Effect.gen(function* () {
       const accessToken = createTestJwt({ chatgpt_account_id: "account-123" })
@@ -202,7 +301,10 @@ describe("Codex", () => {
           responseRequest.headers["chatgpt-account-id"],
           "account-123",
         )
-        assert.strictEqual(seenRequests[0]?.headers["authorization"], undefined)
+        for (const request of seenRequests.slice(0, 3)) {
+          assert.strictEqual(request?.headers["authorization"], undefined)
+          assert.strictEqual(request?.headers["chatgpt-account-id"], undefined)
+        }
         assert.strictEqual(
           JSON.parse(getBody(responseRequest)).model,
           DEFAULT_MODEL,

--- a/src/Codex.ts
+++ b/src/Codex.ts
@@ -1,0 +1,18 @@
+import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai"
+import { Layer } from "effect"
+import { CODEX_API_BASE, CodexAuth } from "./CodexAuth.ts"
+
+const DEFAULT_MODEL = "gpt-5.3-codex"
+
+const clientLayer = OpenAiClient.layer({ apiUrl: CODEX_API_BASE }).pipe(
+  Layer.provide(
+    CodexAuth.layerClient.pipe(Layer.provideMerge(CodexAuth.layer)),
+  ),
+)
+
+export const model = (modelId: string) =>
+  OpenAiLanguageModel.layer({ model: modelId }).pipe(
+    Layer.provideMerge(clientLayer),
+  )
+
+export const layer = model(DEFAULT_MODEL)

--- a/src/CodexAuth.ts
+++ b/src/CodexAuth.ts
@@ -31,6 +31,7 @@ const DEVICE_REDIRECT_URI = `${ISSUER}/deviceauth/callback`
 const DEVICE_VERIFICATION_URL = `${ISSUER}/codex/device`
 const DEFAULT_DEVICE_POLL_INTERVAL_SECONDS = 5
 const DEFAULT_TOKEN_EXPIRY_SECONDS = 3600
+const ACCOUNT_ID_HEADER = "ChatGPT-Account-Id"
 
 export class TokenData extends Schema.Class<TokenData>(
   "clanka/CodexAuth/TokenData",
@@ -174,6 +175,47 @@ const extractAccountIdFromTokens = (
 
   return extractAccountIdFromToken(token.access_token)
 }
+
+const applyTokenHeaders = (
+  request: HttpClientRequest.HttpClientRequest,
+  token: TokenData,
+): HttpClientRequest.HttpClientRequest => {
+  const authenticatedRequest = request.pipe(
+    HttpClientRequest.bearerToken(token.access),
+  )
+
+  return Option.match(token.accountId, {
+    onNone: () => authenticatedRequest,
+    onSome: (accountId) =>
+      authenticatedRequest.pipe(
+        HttpClientRequest.setHeader(ACCOUNT_ID_HEADER, accountId),
+      ),
+  })
+}
+
+const injectAuthHeaders = (
+  request: HttpClientRequest.HttpClientRequest,
+  auth: CodexAuth["Service"],
+): Effect.Effect<HttpClientRequest.HttpClientRequest> =>
+  auth.get.pipe(
+    Effect.map((token) => applyTokenHeaders(request, token)),
+    Effect.catch((error: CodexAuthError) =>
+      Effect.die(
+        new Error(
+          `Failed to inject Codex auth headers for ${request.method} ${request.url}: ${error.message}`,
+          { cause: error },
+        ),
+      ),
+    ),
+  )
+
+const makeLayerClient = (
+  httpClient: HttpClient.HttpClient,
+  auth: CodexAuth["Service"],
+): HttpClient.HttpClient =>
+  httpClient.pipe(
+    HttpClient.mapRequestEffect((request) => injectAuthHeaders(request, auth)),
+  )
 
 const toTokenDataFromResponse = (token: TokenResponse): TokenData =>
   new TokenData({
@@ -498,4 +540,14 @@ export class CodexAuth extends ServiceMap.Service<CodexAuth>()(
   },
 ) {
   static readonly layer = Layer.effect(this, this.make)
+
+  static readonly layerClient = Layer.effect(
+    HttpClient.HttpClient,
+    Effect.gen(function* () {
+      const auth = yield* CodexAuth
+      const httpClient = yield* HttpClient.HttpClient
+
+      return makeLayerClient(httpClient, auth)
+    }),
+  )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * as Codex from "./Codex.ts"
 export {
   CLIENT_ID,
   CodexAuth,


### PR DESCRIPTION
## Summary
- add `CodexAuth.layerClient` so Codex requests pick up bearer and optional account headers from the auth service without feeding the wrapped client back into auth.
- add `src/Codex.ts` and package-root exports so consumers can provide a ready-made Codex `OpenAiClient` and `LanguageModel` layer backed by `https://chatgpt.com/backend-api/codex`.
- add integration coverage for direct header injection, full `Codex.layer` wiring against a mock `HttpClient`, and the new package-root `Codex` export.

## Validation
- `pnpm check`
- `pnpm vitest run`