### PR TITLE
TIM-688: reconcile Codex auth JWT errors

### DIFF
--- a/.specs/openai-codex-auth.md
+++ b/.specs/openai-codex-auth.md
@@ -183,13 +183,16 @@ class CodexAuthError extends Schema.TaggedErrorClass<CodexAuthError>()(
       "DeviceFlowFailed",
       "TokenExchangeFailed",
       "RefreshFailed",
-      "JwtParseFailed",
     ),
     message: Schema.String,
     cause: Schema.optional(Schema.Defect),
   },
 ) {}
 ```
+
+JWT claim parsing is best-effort metadata extraction for the optional
+`ChatGPT-Account-Id` header. Malformed JWTs should stay on the
+`Option.none()` path and must not surface a separate auth error.
 
 ### Service shape
 
@@ -358,7 +361,7 @@ Implement pure JWT parsing/account extraction helpers using
 **Acceptance criteria**
 
 - All account-id claim shapes supported
-- Malformed tokens safely return none/error path
+- Malformed tokens safely return `Option.none()` without entering the auth error channel
 - No `any` usage
 - `pnpm check && pnpm vitest run` passes
 

--- a/.specs/openai-codex-auth.md
+++ b/.specs/openai-codex-auth.md
@@ -192,7 +192,9 @@ class CodexAuthError extends Schema.TaggedErrorClass<CodexAuthError>()(
 
 JWT claim parsing is best-effort metadata extraction for the optional
 `ChatGPT-Account-Id` header. Malformed JWTs should stay on the
-`Option.none()` path and must not surface a separate auth error.
+`Option.none()` path and must not surface a separate auth error. Invalid
+secondary claim shapes should be ignored so valid remaining claim locations can
+still supply an account ID.
 
 ### Service shape
 
@@ -254,6 +256,8 @@ When `get` is called and token is expired:
 
 1. Attempt refresh (`grant_type=refresh_token`)
 2. If refresh succeeds: persist and return refreshed token
+   - If refreshed tokens do not expose a parseable account ID, preserve the
+     previously stored account ID instead of clearing it
 3. If refresh fails: downgrade to fallback (`Option.none`) and run full device
    flow once
 4. If device flow fails: surface `DeviceFlowFailed`

--- a/src/CodexAuth.test.ts
+++ b/src/CodexAuth.test.ts
@@ -197,13 +197,13 @@ describe("CodexAuth", () => {
 
   it("constructs CodexAuthError with the expected tagged shape", () => {
     const error = new CodexAuthError({
-      reason: "JwtParseFailed",
-      message: "Could not decode token claims",
+      reason: "RefreshFailed",
+      message: "Could not refresh the token",
     })
 
     assert.strictEqual(error._tag, "CodexAuthError")
-    assert.strictEqual(error.reason, "JwtParseFailed")
-    assert.strictEqual(error.message, "Could not decode token claims")
+    assert.strictEqual(error.reason, "RefreshFailed")
+    assert.strictEqual(error.message, "Could not refresh the token")
   })
 
   it("parses valid JWT claims from a base64url payload", () => {
@@ -578,6 +578,32 @@ describe("CodexAuth", () => {
         assert.strictEqual(body.get("grant_type"), "refresh_token")
         assert.strictEqual(body.get("refresh_token"), "refresh-token")
         assert.strictEqual(body.get("client_id"), CLIENT_ID)
+      }),
+  )
+
+  it.effect(
+    "ignores malformed id tokens and still derives account ids from the access token",
+    () =>
+      Effect.gen(function* () {
+        const { client } = yield* makeClient(() =>
+          jsonResponse({
+            id_token: "invalid",
+            access_token: createTestJwt({
+              chatgpt_account_id: "from-access-token",
+            }),
+            refresh_token: "next-refresh-token",
+          }),
+        )
+
+        const token = yield* refreshToken("refresh-token").pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+        )
+
+        assert.strictEqual(token.refresh, "next-refresh-token")
+        assert.strictEqual(
+          Option.getOrUndefined(token.accountId),
+          "from-access-token",
+        )
       }),
   )
 

--- a/src/CodexAuth.test.ts
+++ b/src/CodexAuth.test.ts
@@ -238,10 +238,39 @@ describe("CodexAuth", () => {
     )
   })
 
-  it("returns none when decoded claims fail the schema", () => {
+  it("ignores malformed claim types instead of failing the parse", () => {
+    assert.deepStrictEqual(
+      Option.getOrUndefined(
+        parseJwtClaims(createTestJwt({ chatgpt_account_id: 123 })),
+      ),
+      {},
+    )
+  })
+
+  it("keeps valid account ids when other claim locations are malformed", () => {
     assert.strictEqual(
-      Option.isNone(parseJwtClaims(createTestJwt({ chatgpt_account_id: 123 }))),
-      true,
+      Option.getOrUndefined(
+        extractAccountIdFromToken(
+          createTestJwt({
+            chatgpt_account_id: "acc-root",
+            "https://api.openai.com/auth": "invalid",
+          }),
+        ),
+      ),
+      "acc-root",
+    )
+    assert.strictEqual(
+      Option.getOrUndefined(
+        extractAccountIdFromToken(
+          createTestJwt({
+            "https://api.openai.com/auth": {
+              chatgpt_account_id: "acc-nested",
+            },
+            organizations: [123],
+          }),
+        ),
+      ),
+      "acc-nested",
     )
   })
 
@@ -310,6 +339,17 @@ describe("CodexAuth", () => {
         }),
       ),
       "org-123",
+    )
+  })
+
+  it("treats empty organization ids as missing", () => {
+    assert.strictEqual(
+      Option.isNone(
+        extractAccountIdFromClaims({
+          organizations: [{ id: "" }],
+        }),
+      ),
+      true,
     )
   })
 
@@ -543,6 +583,29 @@ describe("CodexAuth", () => {
   )
 
   it.effect(
+    "exchanges tokens with malformed JWT claims without surfacing auth errors",
+    () =>
+      Effect.gen(function* () {
+        const { client } = yield* makeClient(() =>
+          jsonResponse({
+            id_token: "invalid",
+            access_token: "also-invalid",
+            refresh_token: "refresh-token",
+            expires_in: 42,
+          }),
+        )
+
+        const token = yield* exchangeAuthorizationCode({
+          authorizationCode: "authorization-code",
+          codeVerifier: "code-verifier",
+        }).pipe(Effect.provideService(HttpClient.HttpClient, client))
+
+        assert.strictEqual(token.refresh, "refresh-token")
+        assert.strictEqual(Option.isNone(token.accountId), true)
+      }),
+  )
+
+  it.effect(
     "refreshes tokens with urlencoded payloads and access token fallback",
     () =>
       Effect.gen(function* () {
@@ -605,6 +668,81 @@ describe("CodexAuth", () => {
           "from-access-token",
         )
       }),
+  )
+
+  it.effect(
+    "refreshes tokens with malformed JWT claims without surfacing auth errors",
+    () =>
+      Effect.gen(function* () {
+        const { client } = yield* makeClient(() =>
+          jsonResponse({
+            id_token: "invalid",
+            access_token: "also-invalid",
+            refresh_token: "next-refresh-token",
+            expires_in: 120,
+          }),
+        )
+
+        const token = yield* refreshToken("refresh-token").pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+        )
+
+        assert.strictEqual(token.refresh, "next-refresh-token")
+        assert.strictEqual(Option.isNone(token.accountId), true)
+      }),
+  )
+
+  it.effect(
+    "preserves the stored account id when refreshed tokens omit parseable claims",
+    () =>
+      Effect.gen(function* () {
+        const kvs = yield* KeyValueStore.KeyValueStore
+        const tokenStore = toTokenStore(kvs)
+        yield* Effect.orDie(
+          tokenStore.set(
+            STORE_TOKEN_KEY,
+            new TokenData({
+              access: "stale-access-token",
+              refresh: "stale-refresh-token",
+              expires: Date.now() - 60_000,
+              accountId: Option.some("persisted-account"),
+            }),
+          ),
+        )
+
+        const { attempts, client } = yield* makeClient(() =>
+          jsonResponse({
+            id_token: "invalid",
+            access_token: "also-invalid",
+            refresh_token: "next-refresh-token",
+            expires_in: 120,
+          }),
+        )
+
+        const auth = yield* CodexAuth.make.pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+        )
+
+        const token = yield* auth.get
+
+        assert.strictEqual(token.refresh, "next-refresh-token")
+        assert.strictEqual(
+          Option.getOrUndefined(token.accountId),
+          "persisted-account",
+        )
+        assert.strictEqual(yield* Ref.get(attempts), 1)
+
+        const stored = yield* Effect.orDie(tokenStore.get(STORE_TOKEN_KEY))
+        assert.strictEqual(Option.isSome(stored), true)
+        if (Option.isNone(stored)) {
+          return
+        }
+
+        assert.strictEqual(
+          Option.getOrUndefined(stored.value.accountId),
+          "persisted-account",
+        )
+      }).pipe(Effect.provide(KeyValueStore.layerMemory)),
   )
 
   it.effect("captures decode failures when refreshing tokens", () =>

--- a/src/CodexAuth.ts
+++ b/src/CodexAuth.ts
@@ -53,7 +53,6 @@ export class CodexAuthError extends Schema.TaggedErrorClass<CodexAuthError>()(
       "DeviceFlowFailed",
       "TokenExchangeFailed",
       "RefreshFailed",
-      "JwtParseFailed",
     ]),
     message: Schema.String,
     cause: Schema.optional(Schema.Defect),

--- a/src/CodexAuth.ts
+++ b/src/CodexAuth.ts
@@ -90,25 +90,60 @@ export interface AuthorizationCodeData {
   readonly codeVerifier: string
 }
 
-const JwtAccountClaimSchema = Schema.Struct({
-  chatgpt_account_id: Schema.optional(Schema.String),
-})
+export interface JwtClaims {
+  readonly chatgpt_account_id?: string
+  readonly "https://api.openai.com/auth"?: {
+    readonly chatgpt_account_id?: string
+  }
+  readonly organizations?: ReadonlyArray<{
+    readonly id: string
+  }>
+}
 
-const JwtOrganizationSchema = Schema.Struct({
-  id: Schema.String,
-})
-
-const JwtClaimsSchema = Schema.Struct({
-  chatgpt_account_id: Schema.optional(Schema.String),
-  "https://api.openai.com/auth": Schema.optional(JwtAccountClaimSchema),
-  organizations: Schema.optional(Schema.Array(JwtOrganizationSchema)),
-})
-
-export type JwtClaims = typeof JwtClaimsSchema.Type
-
-const decodeJwtClaims = Schema.decodeUnknownOption(
-  Schema.fromJsonString(JwtClaimsSchema),
+const decodeJwtJson = Schema.decodeUnknownOption(
+  Schema.fromJsonString(Schema.Unknown),
 )
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const getString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined
+
+const toJwtClaims = (value: unknown): Option.Option<JwtClaims> => {
+  if (!isRecord(value)) {
+    return Option.none()
+  }
+
+  const accountId = getString(value["chatgpt_account_id"])
+  const authValue = value["https://api.openai.com/auth"]
+  const nestedAccountId = isRecord(authValue)
+    ? getString(authValue["chatgpt_account_id"])
+    : undefined
+  const organizationsValue = value["organizations"]
+  const organizationId =
+    Array.isArray(organizationsValue) &&
+    organizationsValue[0] !== undefined &&
+    isRecord(organizationsValue[0])
+      ? getString(organizationsValue[0]["id"])
+      : undefined
+
+  return Option.some({
+    ...(accountId === undefined ? {} : { chatgpt_account_id: accountId }),
+    ...(nestedAccountId === undefined
+      ? {}
+      : {
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: nestedAccountId,
+          },
+        }),
+    ...(organizationId === undefined
+      ? {}
+      : {
+          organizations: [{ id: organizationId }],
+        }),
+  })
+}
 
 const decodeJwtPayload = (token: string): Option.Option<string> => {
   const parts = token.split(".")
@@ -127,7 +162,10 @@ const decodeJwtPayload = (token: string): Option.Option<string> => {
 }
 
 export const parseJwtClaims = (token: string): Option.Option<JwtClaims> =>
-  decodeJwtPayload(token).pipe(Option.flatMap(decodeJwtClaims))
+  decodeJwtPayload(token).pipe(
+    Option.flatMap(decodeJwtJson),
+    Option.flatMap(toJwtClaims),
+  )
 
 export const extractAccountIdFromClaims = (
   claims: JwtClaims,
@@ -145,7 +183,12 @@ export const extractAccountIdFromClaims = (
     return Option.some(nestedAccountId)
   }
 
-  return Option.fromNullishOr(claims.organizations?.[0]?.id)
+  const organizationId = claims.organizations?.[0]?.id
+  if (organizationId !== undefined && organizationId !== "") {
+    return Option.some(organizationId)
+  }
+
+  return Option.none()
 }
 
 export const extractAccountIdFromToken = (
@@ -224,6 +267,22 @@ const toTokenDataFromResponse = (token: TokenResponse): TokenData =>
       Date.now() + (token.expires_in ?? DEFAULT_TOKEN_EXPIRY_SECONDS) * 1_000,
     accountId: extractAccountIdFromTokens(token),
   })
+
+const preserveAccountId = (
+  token: TokenData,
+  fallback: Option.Option<string>,
+): TokenData => {
+  if (Option.isSome(token.accountId) || Option.isNone(fallback)) {
+    return token
+  }
+
+  return new TokenData({
+    access: token.access,
+    refresh: token.refresh,
+    expires: token.expires,
+    accountId: fallback,
+  })
+}
 
 const requestDeviceCodeError = (message: string, cause?: unknown) =>
   new CodexAuthError({
@@ -521,7 +580,12 @@ export class CodexAuth extends ServiceMap.Service<CodexAuth>()(
           )
 
           if (Option.isSome(refreshedToken)) {
-            return yield* saveToken(refreshedToken.value)
+            return yield* saveToken(
+              preserveAccountId(
+                refreshedToken.value,
+                currentToken.value.accountId,
+              ),
+            )
           }
 
           yield* clearToken


### PR DESCRIPTION
## Summary
- remove the unused `JwtParseFailed` reason from `CodexAuthError` so the public auth API matches runtime behavior
- document in `.specs/openai-codex-auth.md` that JWT claim parsing is best-effort account metadata extraction for the optional `ChatGPT-Account-Id` header
- add test coverage that malformed `id_token` values still fall back to `access_token` account parsing during refresh

## Verification
- `pnpm check`
- `pnpm vitest run`