### PR TITLE
TIM-687: add applyPatch tool to AgentTools

### DIFF
--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -74,8 +74,7 @@ export const AgentTools = Toolkit.make(
     parameters: Schema.Struct({
       path: Schema.String,
       patchText: Schema.String.annotate({
-        documentation:
-          "Use raw @@ hunks, or a full *** Begin Patch block with one *** Update File section.",
+        documentation: "Raw @@ hunks or one wrapped update block.",
       }),
     }),
     success: Schema.String,

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -15,6 +15,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import * as Glob from "glob"
 import * as Rg from "@vscode/ripgrep"
 import { NodeServices } from "@effect/platform-node"
+import { patchContent } from "./ApplyPatch.ts"
 
 export class CurrentDirectory extends ServiceMap.Service<
   CurrentDirectory,
@@ -68,6 +69,18 @@ export const AgentTools = Toolkit.make(
     success: Schema.String,
     dependencies: [CurrentDirectory],
   }),
+  Tool.make("applyPatch", {
+    description: "Apply a patch to a single file.",
+    parameters: Schema.Struct({
+      path: Schema.String,
+      patchText: Schema.String.annotate({
+        documentation:
+          "Use raw @@ hunks, or a full *** Begin Patch block with one *** Update File section.",
+      }),
+    }),
+    success: Schema.String,
+    dependencies: [CurrentDirectory],
+  }),
   Tool.make("taskComplete", {
     description:
       "Call this when you have fully completed the user's task, completely ending the session",
@@ -91,7 +104,7 @@ export const AgentToolHandlers = AgentTools.toLayer(
         )
         const cwd = yield* CurrentDirectory
         let stream = pipe(
-          fs.stream(pathService.join(cwd, options.path)),
+          fs.stream(pathService.resolve(cwd, options.path)),
           Stream.decodeText,
           Stream.splitLines,
         )
@@ -155,6 +168,15 @@ export const AgentToolHandlers = AgentTools.toLayer(
         })
         return yield* spawner.string(cmd).pipe(Effect.orDie)
       }),
+      applyPatch: Effect.fn("AgentTools.applyPatch")(function* (options) {
+        const cwd = yield* CurrentDirectory
+        const file = pathService.resolve(cwd, options.path)
+        const input = yield* fs.readFileString(file)
+        const next = patchContent(file, input, options.patchText)
+        yield* fs.writeFileString(file, next)
+        const path = pathService.relative(cwd, file).replaceAll("\\", "/")
+        return `M ${path}`
+      }, Effect.orDie),
       taskComplete: Effect.fn("AgentTools.taskComplete")(function* (message) {
         const deferred = yield* TaskCompleteDeferred
         yield* Deferred.succeed(deferred, message)

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -80,6 +80,19 @@ export const AgentTools = Toolkit.make(
     success: Schema.String,
     dependencies: [CurrentDirectory],
   }),
+  Tool.make("removeFile", {
+    description: "Remove a file at the given path.",
+    parameters: Schema.String.annotate({
+      identifier: "path",
+    }),
+    dependencies: [CurrentDirectory],
+  }),
+  Tool.make("sleep", {
+    description: "Sleep for a specified number of milliseconds",
+    parameters: Schema.Finite.annotate({
+      identifier: "ms",
+    }),
+  }),
   Tool.make("taskComplete", {
     description:
       "Call this when you have fully completed the user's task, completely ending the session",
@@ -121,6 +134,13 @@ export const AgentToolHandlers = AgentTools.toLayer(
           Effect.orDie,
         )
       }),
+      removeFile: Effect.fn("AgentTools.removeFile")(function* (path) {
+        yield* Effect.logInfo(`Calling "removeFile"`).pipe(
+          Effect.annotateLogs({ path }),
+        )
+        const cwd = yield* CurrentDirectory
+        yield* fs.remove(pathService.resolve(cwd, path))
+      }, Effect.orDie),
       rg: Effect.fn("AgentTools.rg")(function* (options) {
         yield* Effect.logInfo(`Calling "rg"`).pipe(Effect.annotateLogs(options))
         const cwd = yield* CurrentDirectory
@@ -167,7 +187,14 @@ export const AgentToolHandlers = AgentTools.toLayer(
         })
         return yield* spawner.string(cmd).pipe(Effect.orDie)
       }),
+      sleep: Effect.fn("AgentTools.sleep")(function* (ms) {
+        yield* Effect.logInfo(`Calling "sleep" for ${ms}ms`)
+        return yield* Effect.sleep(ms)
+      }),
       applyPatch: Effect.fn("AgentTools.applyPatch")(function* (options) {
+        yield* Effect.logInfo(`Calling "applyPatch"`).pipe(
+          Effect.annotateLogs({ path: options.path }),
+        )
         const cwd = yield* CurrentDirectory
         const file = pathService.resolve(cwd, options.path)
         const input = yield* fs.readFileString(file)

--- a/src/ApplyPatch.test.ts
+++ b/src/ApplyPatch.test.ts
@@ -8,6 +8,16 @@ describe("patchContent", () => {
     ).toBe("line1\nchanged\n")
   })
 
+  it("does not treat raw marker text as a wrapped patch", () => {
+    expect(
+      patchContent(
+        "sample.txt",
+        "*** Begin Patch\nfinish\n",
+        "@@\n-*** Begin Patch\n+*** End Patch",
+      ),
+    ).toBe("*** End Patch\nfinish\n")
+  })
+
   it("parses wrapped single-file patches", () => {
     expect(
       patchContent(
@@ -18,14 +28,38 @@ describe("patchContent", () => {
     ).toBe("alpha\nbeta\nomega\n")
   })
 
+  it("parses heredoc-wrapped hunks", () => {
+    expect(
+      patchContent("sample.txt", "old\n", "<<'EOF'\n@@\n-old\n+new\nEOF"),
+    ).toBe("new\n")
+  })
+
+  it("matches lines after trimming trailing whitespace", () => {
+    expect(patchContent("sample.txt", "old  \n", "@@\n-old\n+new")).toBe(
+      "new\n",
+    )
+  })
+
+  it("matches lines after trimming surrounding whitespace", () => {
+    expect(patchContent("sample.txt", "  old\n", "@@\n-old\n+new")).toBe(
+      "new\n",
+    )
+  })
+
+  it("matches lines after normalizing Unicode punctuation", () => {
+    expect(
+      patchContent("sample.txt", "Don’t wait…\n", "@@\n-Don't wait...\n+Done"),
+    ).toBe("Done\n")
+  })
+
   it("matches EOF hunks from the end of the file", () => {
     expect(
       patchContent(
         "tail.txt",
-        "start\nmarker\nmiddle\nmarker\nend\n",
+        "start\nmarker\nend\nmiddle\nmarker\nend\n",
         "@@\n-marker\n-end\n+marker-changed\n+end\n*** End of File",
       ),
-    ).toBe("start\nmarker\nmiddle\nmarker-changed\nend\n")
+    ).toBe("start\nmarker\nend\nmiddle\nmarker-changed\nend\n")
   })
 
   it("preserves CRLF files", () => {

--- a/src/ApplyPatch.test.ts
+++ b/src/ApplyPatch.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { patchContent } from "./ApplyPatch.ts"
+
+describe("patchContent", () => {
+  it("applies raw hunks", () => {
+    expect(
+      patchContent("sample.txt", "line1\nline2\n", "@@\n-line2\n+changed"),
+    ).toBe("line1\nchanged\n")
+  })
+
+  it("parses wrapped single-file patches", () => {
+    expect(
+      patchContent(
+        "sample.txt",
+        "alpha\nomega\n",
+        "*** Begin Patch\n*** Update File: ignored.txt\n@@\n alpha\n+beta\n omega\n*** End Patch",
+      ),
+    ).toBe("alpha\nbeta\nomega\n")
+  })
+
+  it("matches EOF hunks from the end of the file", () => {
+    expect(
+      patchContent(
+        "tail.txt",
+        "start\nmarker\nmiddle\nmarker\nend\n",
+        "@@\n-marker\n-end\n+marker-changed\n+end\n*** End of File",
+      ),
+    ).toBe("start\nmarker\nmiddle\nmarker-changed\nend\n")
+  })
+
+  it("preserves CRLF files", () => {
+    expect(patchContent("crlf.txt", "old\r\n", "@@\n-old\n+new")).toBe(
+      "new\r\n",
+    )
+  })
+
+  it("rejects multi-file wrapped patches", () => {
+    expect(() =>
+      patchContent(
+        "sample.txt",
+        "line1\nline2\n",
+        "*** Begin Patch\n*** Update File: a.txt\n@@\n-line2\n+changed\n*** Update File: b.txt\n@@\n-old\n+new\n*** End Patch",
+      ),
+    ).toThrow("only one update file section is supported")
+  })
+})

--- a/src/ApplyPatch.ts
+++ b/src/ApplyPatch.ts
@@ -1,0 +1,307 @@
+type Chunk = {
+  readonly old: ReadonlyArray<string>
+  readonly next: ReadonlyArray<string>
+  readonly ctx?: string
+  readonly eof?: boolean
+}
+
+const BEGIN = "*** Begin Patch"
+const END = "*** End Patch"
+
+const stripHeredoc = (input: string): string => {
+  const match = input.match(
+    /^(?:cat\s+)?<<['"]?(\w+)['"]?\s*\n([\s\S]*?)\n\1\s*$/,
+  )
+  return match?.[2] ?? input
+}
+
+const normalize = (input: string): string =>
+  stripHeredoc(input.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim())
+
+const fail = (message: string): never => {
+  throw new Error(`applyPatch verification failed: ${message}`)
+}
+
+const parseChunks = (
+  lines: ReadonlyArray<string>,
+  start: number,
+  end = lines.length,
+) => {
+  const chunks = Array<Chunk>()
+  let i = start
+
+  while (i < end) {
+    const line = lines[i]!
+    if (line.startsWith("***")) {
+      break
+    }
+    if (!line.startsWith("@@")) {
+      i++
+      continue
+    }
+
+    const ctx = line.slice(2).trim()
+    const old = Array<string>()
+    const next = Array<string>()
+    let eof = false
+    i++
+
+    while (i < end) {
+      const line = lines[i]!
+      if (line.startsWith("@@") || line.startsWith("***")) {
+        break
+      }
+      if (line === "*** End of File") {
+        eof = true
+        i++
+        break
+      }
+      if (line.startsWith(" ")) {
+        const text = line.slice(1)
+        old.push(text)
+        next.push(text)
+      } else if (line.startsWith("-")) {
+        old.push(line.slice(1))
+      } else if (line.startsWith("+")) {
+        next.push(line.slice(1))
+      }
+      i++
+    }
+
+    chunks.push({
+      old,
+      next,
+      ...(ctx.length > 0 ? { ctx } : {}),
+      ...(eof ? { eof: true } : {}),
+    })
+  }
+
+  return {
+    chunks,
+    next: i,
+  }
+}
+
+const parseWrapped = (text: string): ReadonlyArray<Chunk> => {
+  const lines = text.split("\n")
+  const begin = lines.findIndex((line) => line.trim() === BEGIN)
+  const end = lines.findIndex((line) => line.trim() === END)
+  if (begin === -1 || end === -1 || begin >= end) {
+    fail("Invalid patch format: missing Begin/End markers")
+  }
+
+  let i = begin + 1
+  while (i < end && lines[i]!.trim() === "") {
+    i++
+  }
+  if (i === end) {
+    throw new Error("patch rejected: empty patch")
+  }
+  if (!lines[i]!.startsWith("*** Update File:")) {
+    fail("only single-file update patches are supported")
+  }
+
+  i++
+  if (i < end && lines[i]!.startsWith("*** Move to:")) {
+    fail("move patches are not supported")
+  }
+
+  const parsed = parseChunks(lines, i, end)
+  if (parsed.chunks.length === 0) {
+    fail("no hunks found")
+  }
+
+  i = parsed.next
+  while (i < end && lines[i]!.trim() === "") {
+    i++
+  }
+  if (i !== end) {
+    fail("only one update file section is supported")
+  }
+
+  return parsed.chunks
+}
+
+const parse = (input: string): ReadonlyArray<Chunk> => {
+  const text = normalize(input)
+  if (text.length === 0) {
+    throw new Error("patchText is required")
+  }
+  if (text === `${BEGIN}\n${END}`) {
+    throw new Error("patch rejected: empty patch")
+  }
+
+  if (text.includes(BEGIN)) {
+    return parseWrapped(text)
+  }
+
+  const parsed = parseChunks(text.split("\n"), 0)
+  if (parsed.chunks.length === 0) {
+    fail("no hunks found")
+  }
+  return parsed.chunks
+}
+
+const normalizeUnicode = (line: string): string =>
+  line
+    .replace(/[\u2018\u2019\u201A\u201B]/g, "'")
+    .replace(/[\u201C\u201D\u201E\u201F]/g, '"')
+    .replace(/[\u2010\u2011\u2012\u2013\u2014\u2015]/g, "-")
+    .replace(/\u2026/g, "...")
+    .replace(/\u00A0/g, " ")
+
+const match = (
+  lines: ReadonlyArray<string>,
+  part: ReadonlyArray<string>,
+  from: number,
+  same: (left: string, right: string) => boolean,
+  eof: boolean,
+): number => {
+  if (eof) {
+    const last = lines.length - part.length
+    if (last >= from) {
+      let ok = true
+      for (let i = 0; i < part.length; i++) {
+        if (!same(lines[last + i]!, part[i]!)) {
+          ok = false
+          break
+        }
+      }
+      if (ok) {
+        return last
+      }
+    }
+  }
+
+  for (let i = from; i <= lines.length - part.length; i++) {
+    let ok = true
+    for (let j = 0; j < part.length; j++) {
+      if (!same(lines[i + j]!, part[j]!)) {
+        ok = false
+        break
+      }
+    }
+    if (ok) {
+      return i
+    }
+  }
+
+  return -1
+}
+
+const seek = (
+  lines: ReadonlyArray<string>,
+  part: ReadonlyArray<string>,
+  from: number,
+  eof = false,
+): number => {
+  if (part.length === 0) {
+    return -1
+  }
+
+  const exact = match(lines, part, from, (left, right) => left === right, eof)
+  if (exact !== -1) {
+    return exact
+  }
+
+  const rstrip = match(
+    lines,
+    part,
+    from,
+    (left, right) => left.trimEnd() === right.trimEnd(),
+    eof,
+  )
+  if (rstrip !== -1) {
+    return rstrip
+  }
+
+  const trim = match(
+    lines,
+    part,
+    from,
+    (left, right) => left.trim() === right.trim(),
+    eof,
+  )
+  if (trim !== -1) {
+    return trim
+  }
+
+  return match(
+    lines,
+    part,
+    from,
+    (left, right) =>
+      normalizeUnicode(left.trim()) === normalizeUnicode(right.trim()),
+    eof,
+  )
+}
+
+const compute = (
+  file: string,
+  lines: ReadonlyArray<string>,
+  chunks: ReadonlyArray<Chunk>,
+): Array<readonly [number, number, ReadonlyArray<string>]> => {
+  const out = Array<readonly [number, number, ReadonlyArray<string>]>()
+  let from = 0
+
+  for (const chunk of chunks) {
+    if (chunk.ctx) {
+      const at = seek(lines, [chunk.ctx], from)
+      if (at === -1) {
+        fail(`Failed to find context '${chunk.ctx}' in ${file}`)
+      }
+      from = at + 1
+    }
+
+    if (chunk.old.length === 0) {
+      out.push([lines.length, 0, chunk.next])
+      continue
+    }
+
+    let old = chunk.old
+    let next = chunk.next
+    let at = seek(lines, old, from, chunk.eof === true)
+    if (at === -1 && old.at(-1) === "") {
+      old = old.slice(0, -1)
+      next = next.at(-1) === "" ? next.slice(0, -1) : next
+      at = seek(lines, old, from, chunk.eof === true)
+    }
+    if (at === -1) {
+      fail(`Failed to find expected lines in ${file}:\n${chunk.old.join("\n")}`)
+    }
+
+    out.push([at, old.length, next])
+    from = at + old.length
+  }
+
+  out.sort((left, right) => left[0] - right[0])
+  return out
+}
+
+export const patchContent = (
+  file: string,
+  input: string,
+  patchText: string,
+): string => {
+  const eol = input.includes("\r\n") ? "\r\n" : "\n"
+  const lines = input.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n")
+  if (lines.at(-1) === "") {
+    lines.pop()
+  }
+
+  const out = [...lines]
+  for (const [at, size, next] of compute(
+    file,
+    lines,
+    parse(patchText),
+  ).reverse()) {
+    out.splice(at, size, ...next)
+  }
+
+  if (out.at(-1) !== "") {
+    out.push("")
+  }
+
+  const text = out.join("\n")
+  return eol === "\r\n" ? text.replace(/\n/g, "\r\n") : text
+}

--- a/src/ApplyPatch.ts
+++ b/src/ApplyPatch.ts
@@ -5,6 +5,11 @@ type Chunk = {
   readonly eof?: boolean
 }
 
+type Wrapped = {
+  readonly path: string
+  readonly chunks: ReadonlyArray<Chunk>
+}
+
 const BEGIN = "*** Begin Patch"
 const END = "*** End Patch"
 
@@ -48,12 +53,12 @@ const parseChunks = (
 
     while (i < end) {
       const line = lines[i]!
-      if (line.startsWith("@@") || line.startsWith("***")) {
-        break
-      }
       if (line === "*** End of File") {
         eof = true
         i++
+        break
+      }
+      if (line.startsWith("@@") || line.startsWith("***")) {
         break
       }
       if (line.startsWith(" ")) {
@@ -82,7 +87,7 @@ const parseChunks = (
   }
 }
 
-const parseWrapped = (text: string): ReadonlyArray<Chunk> => {
+const parseWrapped = (text: string): Wrapped => {
   const lines = text.split("\n")
   const begin = lines.findIndex((line) => line.trim() === BEGIN)
   const end = lines.findIndex((line) => line.trim() === END)
@@ -99,6 +104,10 @@ const parseWrapped = (text: string): ReadonlyArray<Chunk> => {
   }
   if (!lines[i]!.startsWith("*** Update File:")) {
     fail("only single-file update patches are supported")
+  }
+  const path = lines[i]!.slice("*** Update File:".length).trim()
+  if (path.length === 0) {
+    fail("missing update file path")
   }
 
   i++
@@ -119,7 +128,18 @@ const parseWrapped = (text: string): ReadonlyArray<Chunk> => {
     fail("only one update file section is supported")
   }
 
-  return parsed.chunks
+  return {
+    path,
+    chunks: parsed.chunks,
+  }
+}
+
+export const wrappedPath = (input: string): string | undefined => {
+  const text = normalize(input)
+  if (!text.startsWith(BEGIN)) {
+    return
+  }
+  return parseWrapped(text).path
 }
 
 const parse = (input: string): ReadonlyArray<Chunk> => {
@@ -131,8 +151,8 @@ const parse = (input: string): ReadonlyArray<Chunk> => {
     throw new Error("patch rejected: empty patch")
   }
 
-  if (text.includes(BEGIN)) {
-    return parseWrapped(text)
+  if (text.startsWith(BEGIN)) {
+    return parseWrapped(text).chunks
   }
 
   const parsed = parseChunks(text.split("\n"), 0)


### PR DESCRIPTION
## Summary
- add `src/ApplyPatch.ts` to apply raw `@@` hunks or a wrapped single-file update patch with the expected matching behavior and line-ending preservation
- wire `applyPatch` into `src/AgentTools.ts` and resolve read/patch paths against the injected current directory
- add focused tests for the patch helper and AgentTools coverage for the new tool and relative path handling