### PR TITLE
TIM-690 Add python tool for agent scripts

### DIFF
--- a/src/AgentTools.test.ts
+++ b/src/AgentTools.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { basename, join } from "node:path"
 import { Deferred, Effect, Stream } from "effect"
 import { describe, expect, it } from "vitest"
 import {
@@ -36,38 +39,47 @@ describe("AgentTools", () => {
   })
 
   it("runs multiline python scripts in the current directory", async () => {
-    const output = await Effect.runPromise(
-      Effect.gen(function* () {
-        const executor = yield* Executor
-        const tools = yield* AgentTools
+    const tempRoot = await mkdtemp(join(tmpdir(), "clanka-python-"))
+    const cwd = join(tempRoot, "tool cwd")
+    await mkdir(cwd)
+    await writeFile(join(cwd, "value.txt"), "14\n")
 
-        return yield* executor
-          .execute({
-            tools,
-            script: [
-              "const output = await python(`",
-              "from pathlib import Path",
-              "print(Path.cwd().name)",
-              "print(sum(i * i for i in range(4)))",
-              "`)",
-              "console.log(output.trimEnd())",
-            ].join("\n"),
-          })
-          .pipe(Stream.mkString)
-      }).pipe(
-        Effect.provide([
-          AgentToolHandlers,
-          Executor.layer,
-          ToolkitRenderer.layer,
-        ]),
-        Effect.provideService(CurrentDirectory, process.cwd()),
-        Effect.provideServiceEffect(
-          TaskCompleteDeferred,
-          Deferred.make<string>(),
+    try {
+      const output = await Effect.runPromise(
+        Effect.gen(function* () {
+          const executor = yield* Executor
+          const tools = yield* AgentTools
+
+          return yield* executor
+            .execute({
+              tools,
+              script: [
+                "const output = await python(`",
+                "from pathlib import Path",
+                'print(Path("value.txt").read_text().strip())',
+                "print(Path.cwd().name)",
+                "`)",
+                "console.log(output.trimEnd())",
+              ].join("\n"),
+            })
+            .pipe(Stream.mkString)
+        }).pipe(
+          Effect.provide([
+            AgentToolHandlers,
+            Executor.layer,
+            ToolkitRenderer.layer,
+          ]),
+          Effect.provideService(CurrentDirectory, cwd),
+          Effect.provideServiceEffect(
+            TaskCompleteDeferred,
+            Deferred.make<string>(),
+          ),
         ),
-      ),
-    )
+      )
 
-    expect(output).toContain(`${process.cwd().split("/").at(-1)}\n14\n`)
+      expect(output).toContain(`14\n${basename(cwd)}\n`)
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true })
+    }
   })
 })

--- a/src/AgentTools.test.ts
+++ b/src/AgentTools.test.ts
@@ -1,0 +1,73 @@
+import { Deferred, Effect, Stream } from "effect"
+import { describe, expect, it } from "vitest"
+import {
+  AgentToolHandlers,
+  AgentTools,
+  CurrentDirectory,
+  TaskCompleteDeferred,
+} from "./AgentTools.ts"
+import { Executor } from "./Executor.ts"
+import { ToolkitRenderer } from "./ToolkitRenderer.ts"
+
+describe("AgentTools", () => {
+  it("renders a python tool signature", async () => {
+    const output = await Effect.runPromise(
+      Effect.gen(function* () {
+        const renderer = yield* ToolkitRenderer
+        return renderer.render(AgentTools)
+      }).pipe(
+        Effect.provide([
+          AgentToolHandlers,
+          Executor.layer,
+          ToolkitRenderer.layer,
+        ]),
+        Effect.provideService(CurrentDirectory, process.cwd()),
+        Effect.provideServiceEffect(
+          TaskCompleteDeferred,
+          Deferred.make<string>(),
+        ),
+      ),
+    )
+
+    expect(output).toContain("/** Run Python code and return the output. */")
+    expect(output).toContain(
+      "declare function python(script: string): Promise<string>",
+    )
+  })
+
+  it("runs multiline python scripts in the current directory", async () => {
+    const output = await Effect.runPromise(
+      Effect.gen(function* () {
+        const executor = yield* Executor
+        const tools = yield* AgentTools
+
+        return yield* executor
+          .execute({
+            tools,
+            script: [
+              "const output = await python(`",
+              "from pathlib import Path",
+              "print(Path.cwd().name)",
+              "print(sum(i * i for i in range(4)))",
+              "`)",
+              "console.log(output.trimEnd())",
+            ].join("\n"),
+          })
+          .pipe(Stream.mkString)
+      }).pipe(
+        Effect.provide([
+          AgentToolHandlers,
+          Executor.layer,
+          ToolkitRenderer.layer,
+        ]),
+        Effect.provideService(CurrentDirectory, process.cwd()),
+        Effect.provideServiceEffect(
+          TaskCompleteDeferred,
+          Deferred.make<string>(),
+        ),
+      ),
+    )
+
+    expect(output).toContain(`${process.cwd().split("/").at(-1)}\n14\n`)
+  })
+})

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -98,6 +98,14 @@ export const AgentTools = Toolkit.make(
     success: Schema.String,
     dependencies: [CurrentDirectory],
   }),
+  Tool.make("python", {
+    description: "Run Python code and return the output.",
+    parameters: Schema.String.annotate({
+      identifier: "script",
+    }),
+    success: Schema.String,
+    dependencies: [CurrentDirectory],
+  }),
   Tool.make("removeFile", {
     description: "Remove a file at the given path.",
     parameters: Schema.String.annotate({
@@ -220,6 +228,17 @@ export const AgentToolHandlers = AgentTools.toLayer(
         )
         const cwd = yield* CurrentDirectory
         const cmd = ChildProcess.make("bash", ["-c", command], {
+          cwd,
+          stdin: "ignore",
+        })
+        return yield* spawner.string(cmd).pipe(Effect.orDie)
+      }),
+      python: Effect.fn("AgentTools.python")(function* (script) {
+        yield* Effect.logInfo(`Calling "python"`).pipe(
+          Effect.annotateLogs({ script }),
+        )
+        const cwd = yield* CurrentDirectory
+        const cmd = ChildProcess.make("python3", ["-c", script], {
           cwd,
           stdin: "ignore",
         })


### PR DESCRIPTION
## Summary
- add a `python` AgentTools entry that executes Python snippets with `python3` from the current working directory
- keep the AI-facing tool docs and generated signature in sync by defining the tool in `src/AgentTools.ts`
- add end-to-end tests for the rendered toolkit docs and multiline Python execution through `Executor.execute`