### PR TITLE
TIM-691 Add httpGet tool for agent scripts

### DIFF
--- a/src/AgentTools.test.ts
+++ b/src/AgentTools.test.ts
@@ -1,3 +1,4 @@
+import { createServer } from "node:http"
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
@@ -13,7 +14,7 @@ import { Executor } from "./Executor.ts"
 import { ToolkitRenderer } from "./ToolkitRenderer.ts"
 
 describe("AgentTools", () => {
-  it("renders a python tool signature", async () => {
+  it("renders python and httpGet tool signatures", async () => {
     const output = await Effect.runPromise(
       Effect.gen(function* () {
         const renderer = yield* ToolkitRenderer
@@ -35,6 +36,10 @@ describe("AgentTools", () => {
     expect(output).toContain("/** Run Python code and return the output. */")
     expect(output).toContain(
       "declare function python(script: string): Promise<string>",
+    )
+    expect(output).toContain("/** Fetch a URL and return its text response. */")
+    expect(output).toContain(
+      "declare function httpGet(url: string): Promise<string>",
     )
   })
 
@@ -79,6 +84,66 @@ describe("AgentTools", () => {
 
       expect(output).toContain(`14\n${basename(cwd)}\n`)
     } finally {
+      await rm(tempRoot, { force: true, recursive: true })
+    }
+  })
+
+  it("fetches text responses with httpGet", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "clanka-http-get-"))
+    const server = createServer((_request, response) => {
+      response.setHeader("content-type", "text/plain; charset=utf-8")
+      response.end("Hello from httpGet!\n")
+    })
+
+    try {
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", () => resolve())
+      })
+
+      const address = server.address()
+      if (address === null || typeof address === "string") {
+        throw new Error("Expected httpGet test server to listen on a TCP port")
+      }
+
+      const output = await Effect.runPromise(
+        Effect.gen(function* () {
+          const executor = yield* Executor
+          const tools = yield* AgentTools
+
+          return yield* executor
+            .execute({
+              tools,
+              script: [
+                `const output = await httpGet("http://127.0.0.1:${address.port}/message")`,
+                "console.log(output.trimEnd())",
+              ].join("\n"),
+            })
+            .pipe(Stream.mkString)
+        }).pipe(
+          Effect.provide([
+            AgentToolHandlers,
+            Executor.layer,
+            ToolkitRenderer.layer,
+          ]),
+          Effect.provideService(CurrentDirectory, tempRoot),
+          Effect.provideServiceEffect(
+            TaskCompleteDeferred,
+            Deferred.make<string>(),
+          ),
+        ),
+      )
+
+      expect(output).toContain("Hello from httpGet!")
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
+        })
+      })
       await rm(tempRoot, { force: true, recursive: true })
     }
   })

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -106,6 +106,13 @@ export const AgentTools = Toolkit.make(
     success: Schema.String,
     dependencies: [CurrentDirectory],
   }),
+  Tool.make("httpGet", {
+    description: "Fetch a URL and return its text response.",
+    parameters: Schema.String.annotate({
+      identifier: "url",
+    }),
+    success: Schema.String,
+  }),
   Tool.make("removeFile", {
     description: "Remove a file at the given path.",
     parameters: Schema.String.annotate({
@@ -243,6 +250,15 @@ export const AgentToolHandlers = AgentTools.toLayer(
           stdin: "ignore",
         })
         return yield* spawner.string(cmd).pipe(Effect.orDie)
+      }),
+      httpGet: Effect.fn("AgentTools.httpGet")(function* (url) {
+        yield* Effect.logInfo(`Calling "httpGet"`).pipe(
+          Effect.annotateLogs({ url }),
+        )
+        const response = yield* Effect.promise(() => fetch(url)).pipe(
+          Effect.orDie,
+        )
+        return yield* Effect.promise(() => response.text()).pipe(Effect.orDie)
       }),
       sleep: Effect.fn("AgentTools.sleep")(function* (ms) {
         yield* Effect.logInfo(`Calling "sleep" for ${ms}ms`)


### PR DESCRIPTION
## Summary
- add an `httpGet` AgentTools entry that fetches a URL and returns the response text
- expose the new tool in rendered tool signatures so agent scripts can call `httpGet(url)`
- cover the new tool with a renderer assertion and an end-to-end test against a local HTTP server

## Validation
- `pnpm check`
- `pnpm test`
- `pnpm build`