### PR TITLE
TIM-692 Support headers in httpGet tool

### DIFF
--- a/src/AgentTools.test.ts
+++ b/src/AgentTools.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from "node:http"
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { basename, join } from "node:path"
+import { join } from "node:path"
 import { Deferred, Effect, Stream } from "effect"
 import { describe, expect, it } from "vitest"
 import {
@@ -14,7 +14,7 @@ import { Executor } from "./Executor.ts"
 import { ToolkitRenderer } from "./ToolkitRenderer.ts"
 
 describe("AgentTools", () => {
-  it("renders python and httpGet tool signatures", async () => {
+  it("renders the httpGet tool signature", async () => {
     const output = await Effect.runPromise(
       Effect.gen(function* () {
         const renderer = yield* ToolkitRenderer
@@ -33,66 +33,23 @@ describe("AgentTools", () => {
       ),
     )
 
-    expect(output).toContain("/** Run Python code and return the output. */")
-    expect(output).toContain(
-      "declare function python(script: string): Promise<string>",
-    )
     expect(output).toContain("/** Fetch a URL and return its text response. */")
-    expect(output).toContain(
-      "declare function httpGet(url: string): Promise<string>",
-    )
+    expect(output).toContain("declare function httpGet(options: {")
+    expect(output).toContain("readonly url: string;")
+    expect(output).toContain("readonly headers?: {")
+    expect(output).toContain("[x: string]: string;")
+    expect(output).not.toContain("declare function python(")
   })
 
-  it("runs multiline python scripts in the current directory", async () => {
-    const tempRoot = await mkdtemp(join(tmpdir(), "clanka-python-"))
-    const cwd = join(tempRoot, "tool cwd")
-    await mkdir(cwd)
-    await writeFile(join(cwd, "value.txt"), "14\n")
-
-    try {
-      const output = await Effect.runPromise(
-        Effect.gen(function* () {
-          const executor = yield* Executor
-          const tools = yield* AgentTools
-
-          return yield* executor
-            .execute({
-              tools,
-              script: [
-                "const output = await python(`",
-                "from pathlib import Path",
-                'print(Path("value.txt").read_text().strip())',
-                "print(Path.cwd().name)",
-                "`)",
-                "console.log(output.trimEnd())",
-              ].join("\n"),
-            })
-            .pipe(Stream.mkString)
-        }).pipe(
-          Effect.provide([
-            AgentToolHandlers,
-            Executor.layer,
-            ToolkitRenderer.layer,
-          ]),
-          Effect.provideService(CurrentDirectory, cwd),
-          Effect.provideServiceEffect(
-            TaskCompleteDeferred,
-            Deferred.make<string>(),
-          ),
-        ),
-      )
-
-      expect(output).toContain(`14\n${basename(cwd)}\n`)
-    } finally {
-      await rm(tempRoot, { force: true, recursive: true })
-    }
-  })
-
-  it("fetches text responses with httpGet", async () => {
+  it("fetches text responses with httpGet headers", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "clanka-http-get-"))
-    const server = createServer((_request, response) => {
+    const server = createServer((request, response) => {
+      const value = request.headers["x-clanka-token"]
+      const token = Array.isArray(value)
+        ? value.join(",")
+        : (value ?? "missing")
       response.setHeader("content-type", "text/plain; charset=utf-8")
-      response.end("Hello from httpGet!\n")
+      response.end(`Header: ${token}\n`)
     })
 
     try {
@@ -114,7 +71,10 @@ describe("AgentTools", () => {
             .execute({
               tools,
               script: [
-                `const output = await httpGet("http://127.0.0.1:${address.port}/message")`,
+                "const output = await httpGet({",
+                `  url: "http://127.0.0.1:${address.port}/message",`,
+                '  headers: { "x-clanka-token": "secret-value" },',
+                "})",
                 "console.log(output.trimEnd())",
               ].join("\n"),
             })
@@ -133,7 +93,7 @@ describe("AgentTools", () => {
         ),
       )
 
-      expect(output).toContain("Hello from httpGet!")
+      expect(output).toContain("Header: secret-value")
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => {

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -100,8 +100,9 @@ export const AgentTools = Toolkit.make(
   }),
   Tool.make("httpGet", {
     description: "Fetch a URL and return its text response.",
-    parameters: Schema.String.annotate({
-      identifier: "url",
+    parameters: Schema.Struct({
+      url: Schema.String,
+      headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
     }),
     success: Schema.String,
   }),
@@ -232,13 +233,17 @@ export const AgentToolHandlers = AgentTools.toLayer(
         })
         return yield* spawner.string(cmd).pipe(Effect.orDie)
       }),
-      httpGet: Effect.fn("AgentTools.httpGet")(function* (url) {
+      httpGet: Effect.fn("AgentTools.httpGet")(function* (options) {
         yield* Effect.logInfo(`Calling "httpGet"`).pipe(
-          Effect.annotateLogs({ url }),
+          Effect.annotateLogs({ url: options.url }),
         )
-        const response = yield* Effect.promise(() => fetch(url)).pipe(
-          Effect.orDie,
-        )
+        const init =
+          options.headers === undefined
+            ? undefined
+            : { headers: options.headers }
+        const response = yield* Effect.promise(() =>
+          fetch(options.url, init),
+        ).pipe(Effect.orDie)
         return yield* Effect.promise(() => response.text()).pipe(Effect.orDie)
       }),
       sleep: Effect.fn("AgentTools.sleep")(function* (ms) {


### PR DESCRIPTION
## Summary
- update `httpGet` to accept an options object with an optional string-to-string `headers` map and forward those headers to `fetch`
- refresh the rendered-tool test coverage to match the new `httpGet` signature and remove stale python-tool assertions
- extend the end-to-end `httpGet` test to verify custom request headers reach the server

## Validation
- `pnpm check`
- `pnpm test`
- `pnpm build` *(currently fails in this repo because `tsdown.config.ts` points at missing `src/index.ts` and `src/cli.ts` entries)*