### PR TITLE
TIM-694 Support multi-file applyPatch tool

### DIFF
--- a/src/AgentTools.test.ts
+++ b/src/AgentTools.test.ts
@@ -178,4 +178,74 @@ describe("AgentTools", () => {
       await rm(tempRoot, { force: true, recursive: true })
     }
   })
+
+  it("plans later hunks against in-memory file state", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "clanka-apply-patch-state-"))
+
+    try {
+      await mkdir(join(tempRoot, "src"), { recursive: true })
+      await writeFile(join(tempRoot, "src", "app.txt"), "old\n", "utf8")
+
+      const output = await Effect.runPromise(
+        Effect.gen(function* () {
+          const executor = yield* Executor
+          const tools = yield* AgentTools
+
+          return yield* executor
+            .execute({
+              tools,
+              script: [
+                "const output = await applyPatch(`",
+                "*** Begin Patch",
+                "*** Add File: notes/hello.txt",
+                "+hello",
+                "*** Update File: notes/hello.txt",
+                "@@",
+                "-hello",
+                "+hello again",
+                "*** Update File: src/app.txt",
+                "*** Move to: src/main.txt",
+                "@@",
+                "-old",
+                "+new",
+                "*** Update File: src/main.txt",
+                "@@",
+                "-new",
+                "+newer",
+                "*** End Patch",
+                "`)",
+                "console.log(output)",
+              ].join("\n"),
+            })
+            .pipe(Stream.mkString)
+        }).pipe(
+          Effect.provide([
+            AgentToolHandlers,
+            Executor.layer,
+            ToolkitRenderer.layer,
+          ]),
+          Effect.provideService(CurrentDirectory, tempRoot),
+          Effect.provideServiceEffect(
+            TaskCompleteDeferred,
+            Deferred.make<string>(),
+          ),
+        ),
+      )
+
+      expect(output).toContain("A notes/hello.txt")
+      expect(output).toContain("M notes/hello.txt")
+      expect(output).toContain("M src/main.txt")
+      expect(await readFile(join(tempRoot, "notes", "hello.txt"), "utf8")).toBe(
+        "hello again\n",
+      )
+      expect(await readFile(join(tempRoot, "src", "main.txt"), "utf8")).toBe(
+        "newer\n",
+      )
+      await expect(
+        readFile(join(tempRoot, "src", "app.txt"), "utf8"),
+      ).rejects.toThrow()
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true })
+    }
+  })
 })

--- a/src/AgentTools.test.ts
+++ b/src/AgentTools.test.ts
@@ -1,5 +1,5 @@
 import { createServer } from "node:http"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Deferred, Effect, Stream } from "effect"
@@ -14,7 +14,7 @@ import { Executor } from "./Executor.ts"
 import { ToolkitRenderer } from "./ToolkitRenderer.ts"
 
 describe("AgentTools", () => {
-  it("renders the httpGet tool signature", async () => {
+  it("renders the httpGet and applyPatch tool signatures", async () => {
     const output = await Effect.runPromise(
       Effect.gen(function* () {
         const renderer = yield* ToolkitRenderer
@@ -38,6 +38,10 @@ describe("AgentTools", () => {
     expect(output).toContain("readonly url: string;")
     expect(output).toContain("readonly headers?: {")
     expect(output).toContain("[x: string]: string;")
+    expect(output).toContain("/** Apply a patch across one or more files. */")
+    expect(output).toContain(
+      "declare function applyPatch(patchText: /** Wrapped patch with Add/Delete/Update sections. */",
+    )
     expect(output).not.toContain("declare function python(")
   })
 
@@ -104,6 +108,73 @@ describe("AgentTools", () => {
           resolve()
         })
       })
+      await rm(tempRoot, { force: true, recursive: true })
+    }
+  })
+
+  it("applies multi-file patches with add, move, and delete", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "clanka-apply-patch-"))
+
+    try {
+      await mkdir(join(tempRoot, "src"), { recursive: true })
+      await writeFile(join(tempRoot, "src", "app.txt"), "old\n", "utf8")
+      await writeFile(join(tempRoot, "obsolete.txt"), "remove me\n", "utf8")
+
+      const output = await Effect.runPromise(
+        Effect.gen(function* () {
+          const executor = yield* Executor
+          const tools = yield* AgentTools
+
+          return yield* executor
+            .execute({
+              tools,
+              script: [
+                "const output = await applyPatch(`",
+                "*** Begin Patch",
+                "*** Add File: notes/hello.txt",
+                "+hello",
+                "*** Update File: src/app.txt",
+                "*** Move to: src/main.txt",
+                "@@",
+                "-old",
+                "+new",
+                "*** Delete File: obsolete.txt",
+                "*** End Patch",
+                "`)",
+                "console.log(output)",
+              ].join("\n"),
+            })
+            .pipe(Stream.mkString)
+        }).pipe(
+          Effect.provide([
+            AgentToolHandlers,
+            Executor.layer,
+            ToolkitRenderer.layer,
+          ]),
+          Effect.provideService(CurrentDirectory, tempRoot),
+          Effect.provideServiceEffect(
+            TaskCompleteDeferred,
+            Deferred.make<string>(),
+          ),
+        ),
+      )
+
+      expect(output).toContain("A notes/hello.txt")
+      expect(output).toContain("M src/main.txt")
+      expect(output).toContain("D obsolete.txt")
+      expect(await readFile(join(tempRoot, "notes", "hello.txt"), "utf8")).toBe(
+        "hello\n",
+      )
+      expect(await readFile(join(tempRoot, "src", "main.txt"), "utf8")).toBe(
+        "new\n",
+      )
+      await expect(
+        readFile(join(tempRoot, "obsolete.txt"), "utf8"),
+      ).rejects.toThrow()
+      await expect(
+        readFile(join(tempRoot, "src", "app.txt"), "utf8"),
+      ).rejects.toThrow()
+    } finally {
       await rm(tempRoot, { force: true, recursive: true })
     }
   })

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -15,7 +15,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import * as Glob from "glob"
 import * as Rg from "@vscode/ripgrep"
 import { NodeServices } from "@effect/platform-node"
-import { patchContent } from "./ApplyPatch.ts"
+import { parsePatch, patchChunks } from "./ApplyPatch.ts"
 
 export class CurrentDirectory extends ServiceMap.Service<
   CurrentDirectory,
@@ -29,13 +29,10 @@ export class TaskCompleteDeferred extends ServiceMap.Service<
 
 export const AgentTools = Toolkit.make(
   Tool.make("applyPatch", {
-    description:
-      "Apply a patch to a single file. **Use this for updating files**.",
-    parameters: Schema.Struct({
-      path: Schema.String,
-      patchText: Schema.String.annotate({
-        documentation: "Raw @@ hunks or one wrapped update block.",
-      }),
+    description: "Apply a patch across one or more files.",
+    parameters: Schema.String.annotate({
+      identifier: "patchText",
+      documentation: "Wrapped patch with Add/Delete/Update sections.",
     }),
     success: Schema.String,
     dependencies: [CurrentDirectory],
@@ -249,17 +246,149 @@ export const AgentToolHandlers = AgentTools.toLayer(
         yield* Effect.logInfo(`Calling "sleep" for ${ms}ms`)
         return yield* Effect.sleep(ms)
       }),
-      applyPatch: Effect.fn("AgentTools.applyPatch")(function* (options) {
-        yield* Effect.logInfo(`Calling "applyPatch"`).pipe(
-          Effect.annotateLogs({ path: options.path }),
-        )
+      applyPatch: Effect.fn("AgentTools.applyPatch")(function* (patchText) {
+        yield* Effect.logInfo(`Calling "applyPatch"`)
         const cwd = yield* CurrentDirectory
-        const file = pathService.resolve(cwd, options.path)
-        const input = yield* fs.readFileString(file)
-        const next = patchContent(file, input, options.patchText)
-        yield* fs.writeFileString(file, next)
-        const path = pathService.relative(cwd, file).replaceAll("\\", "/")
-        return `M ${path}`
+        const state = new Map<string, string | null>()
+        const steps = [] as Array<
+          | {
+              readonly type: "add" | "update"
+              readonly path: string
+              readonly next: string
+            }
+          | {
+              readonly type: "move"
+              readonly path: string
+              readonly movePath: string
+              readonly next: string
+            }
+          | {
+              readonly type: "delete"
+              readonly path: string
+            }
+        >
+        const out = [] as string[]
+        const rel = (path: string) =>
+          pathService.relative(cwd, path).replaceAll("\\", "/")
+        const load = Effect.fn("AgentTools.applyPatch.load")(function* (
+          path: string,
+          reason: "delete" | "update",
+        ) {
+          const cached = state.get(path)
+          if (cached !== undefined) {
+            if (cached === null) {
+              throw new Error(
+                `applyPatch verification failed: Failed to read file to ${reason}: ${path}`,
+              )
+            }
+            return cached
+          }
+          if (state.has(path)) {
+            throw new Error(
+              `applyPatch verification failed: Failed to read file to ${reason}: ${path}`,
+            )
+          }
+
+          const input = yield* fs
+            .readFileString(path)
+            .pipe(
+              Effect.mapError(
+                () =>
+                  new Error(
+                    `applyPatch verification failed: Failed to read file to ${reason}: ${path}`,
+                  ),
+              ),
+            )
+          state.set(path, input)
+          return input
+        })
+
+        for (const patch of parsePatch(patchText)) {
+          const path = pathService.resolve(cwd, patch.path)
+          switch (patch.type) {
+            case "add": {
+              const next =
+                patch.content.length === 0 || patch.content.endsWith("\n")
+                  ? patch.content
+                  : `${patch.content}\n`
+              state.set(path, next)
+              steps.push({
+                type: "add",
+                path,
+                next,
+              })
+              out.push(`A ${rel(path)}`)
+              break
+            }
+            case "delete": {
+              yield* load(path, "delete")
+              state.set(path, null)
+              steps.push({
+                type: "delete",
+                path,
+              })
+              out.push(`D ${rel(path)}`)
+              break
+            }
+            case "update": {
+              const input = yield* load(path, "update")
+              const next = patchChunks(path, input, patch.chunks)
+              const movePath =
+                patch.movePath === undefined
+                  ? undefined
+                  : pathService.resolve(cwd, patch.movePath)
+
+              if (movePath === undefined || movePath === path) {
+                state.set(path, next)
+                steps.push({
+                  type: "update",
+                  path,
+                  next,
+                })
+                out.push(`M ${rel(path)}`)
+                break
+              }
+
+              state.set(path, null)
+              state.set(movePath, next)
+              steps.push({
+                type: "move",
+                path,
+                movePath,
+                next,
+              })
+              out.push(`M ${rel(movePath)}`)
+              break
+            }
+          }
+        }
+
+        for (const step of steps) {
+          switch (step.type) {
+            case "add":
+            case "update": {
+              yield* fs.makeDirectory(pathService.dirname(step.path), {
+                recursive: true,
+              })
+              yield* fs.writeFileString(step.path, step.next)
+              break
+            }
+            case "move": {
+              yield* fs.makeDirectory(pathService.dirname(step.movePath), {
+                recursive: true,
+              })
+              yield* fs.writeFileString(step.movePath, step.next)
+              yield* fs.remove(step.path)
+              break
+            }
+            case "delete": {
+              yield* fs.remove(step.path)
+              break
+            }
+          }
+        }
+
+        return `Success. Updated the following files:\n${out.join("\n")}`
       }, Effect.orDie),
       taskComplete: Effect.fn("AgentTools.taskComplete")(function* (message) {
         const deferred = yield* TaskCompleteDeferred

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -249,6 +249,14 @@ export const AgentToolHandlers = AgentTools.toLayer(
       applyPatch: Effect.fn("AgentTools.applyPatch")(function* (patchText) {
         yield* Effect.logInfo(`Calling "applyPatch"`)
         const cwd = yield* CurrentDirectory
+        const err = (cause: unknown) =>
+          cause instanceof Error ? cause : new Error(String(cause))
+        const fail = (path: string, reason: "delete" | "update") =>
+          Effect.fail(
+            new Error(
+              `applyPatch verification failed: Failed to read file to ${reason}: ${path}`,
+            ),
+          )
         const state = new Map<string, string | null>()
         const steps = [] as Array<
           | {
@@ -274,19 +282,12 @@ export const AgentToolHandlers = AgentTools.toLayer(
           path: string,
           reason: "delete" | "update",
         ) {
-          const cached = state.get(path)
-          if (cached !== undefined) {
-            if (cached === null) {
-              throw new Error(
-                `applyPatch verification failed: Failed to read file to ${reason}: ${path}`,
-              )
-            }
-            return cached
-          }
           if (state.has(path)) {
-            throw new Error(
-              `applyPatch verification failed: Failed to read file to ${reason}: ${path}`,
-            )
+            const input = state.get(path)
+            if (input === null) {
+              return yield* fail(path, reason)
+            }
+            return input!
           }
 
           const input = yield* fs
@@ -303,7 +304,10 @@ export const AgentToolHandlers = AgentTools.toLayer(
           return input
         })
 
-        for (const patch of parsePatch(patchText)) {
+        for (const patch of yield* Effect.try({
+          try: () => parsePatch(patchText),
+          catch: err,
+        })) {
           const path = pathService.resolve(cwd, patch.path)
           switch (patch.type) {
             case "add": {
@@ -332,7 +336,10 @@ export const AgentToolHandlers = AgentTools.toLayer(
             }
             case "update": {
               const input = yield* load(path, "update")
-              const next = patchChunks(path, input, patch.chunks)
+              const next = yield* Effect.try({
+                try: () => patchChunks(path, input, patch.chunks),
+                catch: err,
+              })
               const movePath =
                 patch.movePath === undefined
                   ? undefined

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -1,5 +1,6 @@
 import {
   Array,
+  Data,
   Deferred,
   Effect,
   FileSystem,
@@ -29,7 +30,8 @@ export class TaskCompleteDeferred extends ServiceMap.Service<
 
 export const AgentTools = Toolkit.make(
   Tool.make("applyPatch", {
-    description: "Apply a patch across one or more files.",
+    description:
+      "Apply a patch across one or more files. Use this to add, delete or update files.",
     parameters: Schema.String.annotate({
       identifier: "patchText",
       documentation: "Wrapped patch with Add/Delete/Update sections.",
@@ -46,14 +48,6 @@ export const AgentTools = Toolkit.make(
       endLine: Schema.optional(Schema.Number),
     }),
     success: Schema.NullOr(Schema.String),
-    dependencies: [CurrentDirectory],
-  }),
-  Tool.make("writeFile", {
-    description: "Write content to a file, replacing it if it already exists.",
-    parameters: Schema.Struct({
-      path: Schema.String,
-      content: Schema.String,
-    }),
     dependencies: [CurrentDirectory],
   }),
   Tool.make("ls", {
@@ -93,13 +87,6 @@ export const AgentTools = Toolkit.make(
       identifier: "command",
     }),
     success: Schema.String,
-    dependencies: [CurrentDirectory],
-  }),
-  Tool.make("removeFile", {
-    description: "Remove a file at the given path.",
-    parameters: Schema.String.annotate({
-      identifier: "path",
-    }),
     dependencies: [CurrentDirectory],
   }),
   Tool.make("sleep", {
@@ -152,23 +139,6 @@ export const AgentToolHandlers = AgentTools.toLayer(
           Effect.orDie,
         )
       }),
-      writeFile: Effect.fn("AgentTools.writeFile")(function* (options) {
-        yield* Effect.logInfo(`Calling "writeFile"`).pipe(
-          Effect.annotateLogs({ path: options.path }),
-        )
-        const cwd = yield* CurrentDirectory
-        yield* fs.writeFileString(
-          pathService.resolve(cwd, options.path),
-          options.content,
-        )
-      }, Effect.orDie),
-      removeFile: Effect.fn("AgentTools.removeFile")(function* (path) {
-        yield* Effect.logInfo(`Calling "removeFile"`).pipe(
-          Effect.annotateLogs({ path }),
-        )
-        const cwd = yield* CurrentDirectory
-        yield* fs.remove(pathService.resolve(cwd, path))
-      }, Effect.orDie),
       ls: Effect.fn("AgentTools.ls")(function* (path) {
         yield* Effect.logInfo(`Calling "readdir"`).pipe(
           Effect.annotateLogs({ path }),
@@ -249,13 +219,13 @@ export const AgentToolHandlers = AgentTools.toLayer(
       applyPatch: Effect.fn("AgentTools.applyPatch")(function* (patchText) {
         yield* Effect.logInfo(`Calling "applyPatch"`)
         const cwd = yield* CurrentDirectory
-        const err = (cause: unknown) =>
-          cause instanceof Error ? cause : new Error(String(cause))
+        // const err = (cause: unknown) =>
+        //   cause instanceof Error ? cause : new Error(String(cause))
         const fail = (path: string, reason: "delete" | "update") =>
           Effect.fail(
-            new Error(
-              `applyPatch verification failed: Failed to read file to ${reason}: ${path}`,
-            ),
+            new ApplyPatchError({
+              message: `verification failed: Failed to read file to ${reason}: ${path}`,
+            }),
           )
         const state = new Map<string, string | null>()
         const steps = [] as Array<
@@ -290,24 +260,12 @@ export const AgentToolHandlers = AgentTools.toLayer(
             return input!
           }
 
-          const input = yield* fs
-            .readFileString(path)
-            .pipe(
-              Effect.mapError(
-                () =>
-                  new Error(
-                    `applyPatch verification failed: Failed to read file to ${reason}: ${path}`,
-                  ),
-              ),
-            )
+          const input = yield* fs.readFileString(path)
           state.set(path, input)
           return input
         })
 
-        for (const patch of yield* Effect.try({
-          try: () => parsePatch(patchText),
-          catch: err,
-        })) {
+        for (const patch of parsePatch(patchText)) {
           const path = pathService.resolve(cwd, patch.path)
           switch (patch.type) {
             case "add": {
@@ -336,10 +294,7 @@ export const AgentToolHandlers = AgentTools.toLayer(
             }
             case "update": {
               const input = yield* load(path, "update")
-              const next = yield* Effect.try({
-                try: () => patchChunks(path, input, patch.chunks),
-                catch: err,
-              })
+              const next = patchChunks(path, input, patch.chunks)
               const movePath =
                 patch.movePath === undefined
                   ? undefined
@@ -404,3 +359,7 @@ export const AgentToolHandlers = AgentTools.toLayer(
     })
   }),
 ).pipe(Layer.provide(NodeServices.layer))
+
+export class ApplyPatchError extends Data.TaggedClass("ApplyPatchError")<{
+  readonly message: string
+}> {}

--- a/src/ApplyPatch.test.ts
+++ b/src/ApplyPatch.test.ts
@@ -70,6 +70,38 @@ describe("patchContent", () => {
     ])
   })
 
+  it("parses wrapped patches when hunks contain marker text", () => {
+    expect(
+      parsePatch(
+        [
+          "*** Begin Patch",
+          "*** Update File: src/app.ts",
+          "@@",
+          " *** End Patch",
+          "-old",
+          "+new",
+          "*** Delete File: obsolete.txt",
+          "*** End Patch",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      {
+        type: "update",
+        path: "src/app.ts",
+        chunks: [
+          {
+            old: ["*** End Patch", "old"],
+            next: ["*** End Patch", "new"],
+          },
+        ],
+      },
+      {
+        type: "delete",
+        path: "obsolete.txt",
+      },
+    ])
+  })
+
   it("parses heredoc-wrapped hunks", () => {
     expect(
       patchContent("sample.txt", "old\n", "<<'EOF'\n@@\n-old\n+new\nEOF"),

--- a/src/ApplyPatch.test.ts
+++ b/src/ApplyPatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { patchContent } from "./ApplyPatch.ts"
+import { parsePatch, patchContent } from "./ApplyPatch.ts"
 
 describe("patchContent", () => {
   it("applies raw hunks", () => {
@@ -26,6 +26,48 @@ describe("patchContent", () => {
         "*** Begin Patch\n*** Update File: ignored.txt\n@@\n alpha\n+beta\n omega\n*** End Patch",
       ),
     ).toBe("alpha\nbeta\nomega\n")
+  })
+
+  it("parses multi-file wrapped patches", () => {
+    expect(
+      parsePatch(
+        [
+          "*** Begin Patch",
+          "*** Add File: hello.txt",
+          "+Hello world",
+          "*** Update File: src/app.ts",
+          "*** Move to: src/main.ts",
+          "@@ keep",
+          " keep",
+          "-old",
+          "+new",
+          "*** Delete File: obsolete.txt",
+          "*** End Patch",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      {
+        type: "add",
+        path: "hello.txt",
+        content: "Hello world",
+      },
+      {
+        type: "update",
+        path: "src/app.ts",
+        movePath: "src/main.ts",
+        chunks: [
+          {
+            ctx: "keep",
+            old: ["keep", "old"],
+            next: ["keep", "new"],
+          },
+        ],
+      },
+      {
+        type: "delete",
+        path: "obsolete.txt",
+      },
+    ])
   })
 
   it("parses heredoc-wrapped hunks", () => {

--- a/src/ApplyPatch.ts
+++ b/src/ApplyPatch.ts
@@ -50,8 +50,8 @@ const fail = (message: string): never => {
 
 const locate = (text: string) => {
   const lines = text.split("\n")
-  const begin = lines.findIndex((line) => line.trim() === BEGIN)
-  const end = lines.findIndex((line) => line.trim() === END)
+  const begin = lines.findIndex((line) => line === BEGIN)
+  const end = lines.findIndex((line) => line === END)
   if (begin === -1 || end === -1 || begin >= end) {
     fail("Invalid patch format: missing Begin/End markers")
   }

--- a/src/ApplyPatch.ts
+++ b/src/ApplyPatch.ts
@@ -1,4 +1,4 @@
-type Chunk = {
+export type Chunk = {
   readonly old: ReadonlyArray<string>
   readonly next: ReadonlyArray<string>
   readonly ctx?: string
@@ -10,8 +10,29 @@ type Wrapped = {
   readonly chunks: ReadonlyArray<Chunk>
 }
 
+export type FilePatch =
+  | {
+      readonly type: "add"
+      readonly path: string
+      readonly content: string
+    }
+  | {
+      readonly type: "delete"
+      readonly path: string
+    }
+  | {
+      readonly type: "update"
+      readonly path: string
+      readonly chunks: ReadonlyArray<Chunk>
+      readonly movePath?: string
+    }
+
 const BEGIN = "*** Begin Patch"
 const END = "*** End Patch"
+const ADD = "*** Add File:"
+const DELETE = "*** Delete File:"
+const MOVE = "*** Move to:"
+const UPDATE = "*** Update File:"
 
 const stripHeredoc = (input: string): string => {
   const match = input.match(
@@ -25,6 +46,20 @@ const normalize = (input: string): string =>
 
 const fail = (message: string): never => {
   throw new Error(`applyPatch verification failed: ${message}`)
+}
+
+const locate = (text: string) => {
+  const lines = text.split("\n")
+  const begin = lines.findIndex((line) => line.trim() === BEGIN)
+  const end = lines.findIndex((line) => line.trim() === END)
+  if (begin === -1 || end === -1 || begin >= end) {
+    fail("Invalid patch format: missing Begin/End markers")
+  }
+  return {
+    lines,
+    begin,
+    end,
+  }
 }
 
 const parseChunks = (
@@ -88,12 +123,7 @@ const parseChunks = (
 }
 
 const parseWrapped = (text: string): Wrapped => {
-  const lines = text.split("\n")
-  const begin = lines.findIndex((line) => line.trim() === BEGIN)
-  const end = lines.findIndex((line) => line.trim() === END)
-  if (begin === -1 || end === -1 || begin >= end) {
-    fail("Invalid patch format: missing Begin/End markers")
-  }
+  const { lines, begin, end } = locate(text)
 
   let i = begin + 1
   while (i < end && lines[i]!.trim() === "") {
@@ -102,16 +132,16 @@ const parseWrapped = (text: string): Wrapped => {
   if (i === end) {
     throw new Error("patch rejected: empty patch")
   }
-  if (!lines[i]!.startsWith("*** Update File:")) {
+  if (!lines[i]!.startsWith(UPDATE)) {
     fail("only single-file update patches are supported")
   }
-  const path = lines[i]!.slice("*** Update File:".length).trim()
+  const path = lines[i]!.slice(UPDATE.length).trim()
   if (path.length === 0) {
     fail("missing update file path")
   }
 
   i++
-  if (i < end && lines[i]!.startsWith("*** Move to:")) {
+  if (i < end && lines[i]!.startsWith(MOVE)) {
     fail("move patches are not supported")
   }
 
@@ -132,6 +162,116 @@ const parseWrapped = (text: string): Wrapped => {
     path,
     chunks: parsed.chunks,
   }
+}
+
+const parseAdd = (lines: ReadonlyArray<string>, start: number, end: number) => {
+  const out = Array<string>()
+  let i = start
+
+  while (i < end) {
+    const line = lines[i]!
+    if (line.startsWith("***")) {
+      break
+    }
+    if (line.startsWith("+")) {
+      out.push(line.slice(1))
+    }
+    i++
+  }
+
+  return {
+    content: out.join("\n"),
+    next: i,
+  }
+}
+
+export const parsePatch = (input: string): ReadonlyArray<FilePatch> => {
+  const text = normalize(input)
+  if (text.length === 0) {
+    throw new Error("patchText is required")
+  }
+  if (text === `${BEGIN}\n${END}`) {
+    throw new Error("patch rejected: empty patch")
+  }
+
+  const { lines, begin, end } = locate(text)
+  const out = Array<FilePatch>()
+  let i = begin + 1
+
+  while (i < end) {
+    while (i < end && lines[i]!.trim() === "") {
+      i++
+    }
+    if (i === end) {
+      break
+    }
+
+    const line = lines[i]!
+    if (line.startsWith(ADD)) {
+      const path = line.slice(ADD.length).trim()
+      if (path.length === 0) {
+        fail("missing add file path")
+      }
+      const parsed = parseAdd(lines, i + 1, end)
+      out.push({
+        type: "add",
+        path,
+        content: parsed.content,
+      })
+      i = parsed.next
+      continue
+    }
+    if (line.startsWith(DELETE)) {
+      const path = line.slice(DELETE.length).trim()
+      if (path.length === 0) {
+        fail("missing delete file path")
+      }
+      out.push({
+        type: "delete",
+        path,
+      })
+      i++
+      continue
+    }
+    if (line.startsWith(UPDATE)) {
+      const path = line.slice(UPDATE.length).trim()
+      if (path.length === 0) {
+        fail("missing update file path")
+      }
+
+      i++
+      let movePath: string | undefined
+      if (i < end && lines[i]!.startsWith(MOVE)) {
+        movePath = lines[i]!.slice(MOVE.length).trim()
+        if (movePath.length === 0) {
+          fail("missing move file path")
+        }
+        i++
+      }
+
+      const parsed = parseChunks(lines, i, end)
+      if (parsed.chunks.length === 0) {
+        fail("no hunks found")
+      }
+
+      out.push({
+        type: "update",
+        path,
+        chunks: parsed.chunks,
+        ...(movePath === undefined ? {} : { movePath }),
+      })
+      i = parsed.next
+      continue
+    }
+
+    fail(`unexpected line in wrapped patch: ${line}`)
+  }
+
+  if (out.length === 0) {
+    fail("no hunks found")
+  }
+
+  return out
 }
 
 export const wrappedPath = (input: string): string | undefined => {
@@ -298,10 +438,10 @@ const compute = (
   return out
 }
 
-export const patchContent = (
+export const patchChunks = (
   file: string,
   input: string,
-  patchText: string,
+  chunks: ReadonlyArray<Chunk>,
 ): string => {
   const eol = input.includes("\r\n") ? "\r\n" : "\n"
   const lines = input.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n")
@@ -310,11 +450,7 @@ export const patchContent = (
   }
 
   const out = [...lines]
-  for (const [at, size, next] of compute(
-    file,
-    lines,
-    parse(patchText),
-  ).reverse()) {
+  for (const [at, size, next] of compute(file, lines, chunks).reverse()) {
     out.splice(at, size, ...next)
   }
 
@@ -325,3 +461,9 @@ export const patchContent = (
   const text = out.join("\n")
   return eol === "\r\n" ? text.replace(/\n/g, "\r\n") : text
 }
+
+export const patchContent = (
+  file: string,
+  input: string,
+  patchText: string,
+): string => patchChunks(file, input, parse(patchText))


### PR DESCRIPTION
## Summary
- add wrapped multi-file patch parsing for `applyPatch`, including add, delete, update, and move sections while preserving the existing single-file hunk matcher
- update `AgentTools` so `applyPatch` takes one `patchText` string, plans sequential add/update/move/delete steps relative to `CurrentDirectory`, and keeps patch verification inside Effect failures instead of throwing from `Effect.gen`
- harden patch marker parsing so wrapped hunks can match literal `*** End Patch` file content, and expand tests to cover marker text plus later hunks that build on in-memory file state

## Validation
- `pnpm test`
- `pnpm check`
- `pnpm build` *(currently fails because `tsdown.config.ts` still references missing `src/index.ts` and `src/cli.ts`; tracked separately)*
