### PR TITLE
TIM-714 Add noIgnore option to ripgrep tool

### DIFF
--- a/.changeset/tim-714-rg-no-ignore.md
+++ b/.changeset/tim-714-rg-no-ignore.md
@@ -1,0 +1,5 @@
+---
+"clanka": patch
+---
+
+Add a noIgnore option to the rg tool so ripgrep searches can include ignored files when requested.

--- a/src/AgentTools.test.ts
+++ b/src/AgentTools.test.ts
@@ -36,6 +36,7 @@ describe("AgentTools", () => {
       expect(output).toContain("readonly path: string;")
       expect(output).toContain("readonly startLine?: number | undefined;")
       expect(output).toContain("readonly endLine?: number | undefined;")
+      expect(output).toContain("readonly noIgnore?: boolean | undefined;")
       expect(output).toContain(
         "/** Apply a git diff / unified diff patch, or a wrapped apply_patch patch, across one or more files. */",
       )
@@ -842,6 +843,110 @@ describe("AgentTools", () => {
         Executor.layer,
         ToolkitRenderer.layer,
         NodeFileSystem.layer,
+      ]),
+      Effect.provide(NodeServices.layer),
+    ),
+  )
+
+  it.effect("rg respects ignore files by default and can disable them", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const tempRoot = yield* makeTempRoot("clanka-rg-ignore-")
+      yield* fs.writeFileString(join(tempRoot, ".ignore"), "ignored.txt\n")
+      yield* fs.writeFileString(
+        join(tempRoot, "visible.txt"),
+        "match visible\n",
+      )
+      yield* fs.writeFileString(
+        join(tempRoot, "ignored.txt"),
+        "match ignored\n",
+      )
+
+      const executor = yield* Executor
+      const tools = yield* AgentTools
+
+      const defaultOutput = yield* executor
+        .execute({
+          tools,
+          script: [
+            'const output = await rg({ pattern: "match" })',
+            "console.log(output)",
+          ].join("\n"),
+        })
+        .pipe(
+          Stream.mkString,
+          Effect.provideServices(makeContextNoop(tempRoot)),
+        )
+
+      expect(defaultOutput).toContain("visible.txt:1:match visible")
+      expect(defaultOutput).not.toContain("ignored.txt:1:match ignored")
+
+      const noIgnoreOutput = yield* executor
+        .execute({
+          tools,
+          script: [
+            'const output = await rg({ pattern: "match", noIgnore: true })',
+            "console.log(output)",
+          ].join("\n"),
+        })
+        .pipe(
+          Stream.mkString,
+          Effect.provideServices(makeContextNoop(tempRoot)),
+        )
+
+      expect(noIgnoreOutput).toContain("visible.txt:1:match visible")
+      expect(noIgnoreOutput).toContain("ignored.txt:1:match ignored")
+    }).pipe(
+      Effect.provide([
+        AgentToolHandlers,
+        Executor.layer,
+        ToolkitRenderer.layer,
+      ]),
+      Effect.provide(NodeServices.layer),
+    ),
+  )
+
+  it.effect("rg combines noIgnore with glob and maxLines", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const tempRoot = yield* makeTempRoot("clanka-rg-no-ignore-glob-")
+      yield* fs.writeFileString(join(tempRoot, ".ignore"), "ignored-*.txt\n")
+      yield* fs.writeFileString(join(tempRoot, "ignored-a.txt"), "needle one\n")
+      yield* fs.writeFileString(join(tempRoot, "ignored-b.txt"), "needle two\n")
+      yield* fs.writeFileString(
+        join(tempRoot, "visible.txt"),
+        "needle visible\n",
+      )
+
+      const executor = yield* Executor
+      const tools = yield* AgentTools
+      const output = yield* executor
+        .execute({
+          tools,
+          script: [
+            "const output = await rg({",
+            '  pattern: "needle",',
+            '  glob: "ignored-*.txt",',
+            "  noIgnore: true,",
+            "  maxLines: 1,",
+            "})",
+            "console.log(output)",
+          ].join("\n"),
+        })
+        .pipe(
+          Stream.mkString,
+          Effect.provideServices(makeContextNoop(tempRoot)),
+        )
+
+      const lines = output.trimEnd().split("\n")
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toMatch(/ignored-[ab]\.txt:1:needle (one|two)/)
+      expect(output).not.toContain("visible.txt:1:needle visible")
+    }).pipe(
+      Effect.provide([
+        AgentToolHandlers,
+        Executor.layer,
+        ToolkitRenderer.layer,
       ]),
       Effect.provide(NodeServices.layer),
     ),

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -131,6 +131,9 @@ export const AgentTools = Toolkit.make(
       glob: Schema.optional(Schema.String).annotate({
         documentation: "--glob",
       }),
+      noIgnore: Schema.optional(Schema.Boolean).annotate({
+        documentation: "--no-ignore",
+      }),
       maxLines: Schema.optional(Schema.Finite).annotate({
         documentation:
           "The total maximum number of lines to return across all files (default: 500)",
@@ -300,6 +303,9 @@ export const AgentToolHandlers = AgentTools.toLayer(
         const args = ["--max-filesize", "1M", "--line-number"]
         if (options.glob) {
           args.push("--glob", options.glob)
+        }
+        if (options.noIgnore) {
+          args.push("--no-ignore")
         }
         args.push(options.pattern)
         let stream = pipe(


### PR DESCRIPTION
## Summary

- add an optional `noIgnore` flag to the `rg` tool schema and rendered typings
- pass `--no-ignore` to ripgrep when `noIgnore: true` is requested
- add regression tests for default ignore behavior and for `noIgnore` with `glob` and `maxLines`

## Validation

- `pnpm check`
- `pnpm test`