### PR TITLE
TIM-718 Add DuckDuckGo API client service

### DIFF
--- a/.changeset/tiny-parrots-smash.md
+++ b/.changeset/tiny-parrots-smash.md
@@ -1,0 +1,5 @@
+---
+"clanka": patch
+---
+
+Add a new `DuckDuckGo` Effect service in `src/DuckDuckGo.ts` with a `search(query)` API that calls the DuckDuckGo Instant Answer API and returns normalized `SearchResult` values, plus a typed `DuckDuckGoError`. Also export the module from `src/index.ts`.

--- a/src/DuckDuckGo.test.ts
+++ b/src/DuckDuckGo.test.ts
@@ -1,0 +1,182 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Ref } from "effect"
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http"
+import { DuckDuckGo } from "./DuckDuckGo.ts"
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  })
+
+const makeClient = Effect.fn("makeClient")(function* (
+  handler: (
+    request: HttpClientRequest.HttpClientRequest,
+    attempt: number,
+  ) => Response,
+) {
+  const attempts = yield* Ref.make(0)
+  const requests = yield* Ref.make<Array<HttpClientRequest.HttpClientRequest>>(
+    [],
+  )
+  const client = HttpClient.make((request) =>
+    Effect.gen(function* () {
+      const attempt = yield* Ref.updateAndGet(attempts, (count) => count + 1)
+      yield* Ref.update(requests, (current) => [...current, request])
+      return HttpClientResponse.fromWeb(request, handler(request, attempt))
+    }),
+  )
+
+  return {
+    attempts,
+    client,
+    requests,
+  } as const
+})
+
+describe("DuckDuckGo", () => {
+  it.effect("returns an empty array for blank queries", () =>
+    Effect.gen(function* () {
+      const { attempts, client } = yield* makeClient(
+        () => new Response(null, { status: 500 }),
+      )
+      const duckDuckGo = yield* DuckDuckGo.make.pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+      )
+
+      const results = yield* duckDuckGo.search("   ")
+
+      assert.deepStrictEqual(results, [])
+      assert.strictEqual(yield* Ref.get(attempts), 0)
+    }),
+  )
+
+  it.effect("normalizes abstract and related topic results", () =>
+    Effect.gen(function* () {
+      const { client, requests } = yield* makeClient(() =>
+        jsonResponse({
+          Heading: "Effect",
+          AbstractText: "Typed functional programming for TypeScript",
+          AbstractURL: "https://effect.website",
+          Results: [
+            {
+              Text: "Effect docs - Official documentation",
+              FirstURL: "https://effect.website/docs",
+            },
+          ],
+          RelatedTopics: [
+            {
+              Name: "Guides",
+              Topics: [
+                {
+                  Text: "Effect docs - Duplicate entry",
+                  FirstURL: "https://effect.website/docs",
+                },
+                {
+                  Text: "GitHub - Effect repository",
+                  FirstURL: "https://github.com/Effect-TS/effect",
+                },
+              ],
+            },
+            {
+              Text: "No separator text",
+              FirstURL: "https://example.com/no-separator",
+            },
+          ],
+        }),
+      )
+      const duckDuckGo = yield* DuckDuckGo.make.pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+      )
+
+      const results = yield* duckDuckGo.search("effect")
+      const seenRequests = yield* Ref.get(requests)
+
+      assert.strictEqual(seenRequests.length, 1)
+      assert.strictEqual(seenRequests[0]?.url, "https://api.duckduckgo.com/")
+      assert.deepStrictEqual(seenRequests[0]?.urlParams.toJSON(), {
+        _id: "UrlParams",
+        params: {
+          q: "effect",
+          format: "json",
+          no_html: "1",
+          no_redirect: "1",
+          skip_disambig: "1",
+        },
+      })
+      assert.deepStrictEqual(
+        results.map((result) => ({
+          title: result.title,
+          url: result.url,
+          description: result.description,
+        })),
+        [
+          {
+            title: "Effect",
+            url: "https://effect.website",
+            description: "Typed functional programming for TypeScript",
+          },
+          {
+            title: "Effect docs",
+            url: "https://effect.website/docs",
+            description: "Official documentation",
+          },
+          {
+            title: "GitHub",
+            url: "https://github.com/Effect-TS/effect",
+            description: "Effect repository",
+          },
+          {
+            title: "No separator text",
+            url: "https://example.com/no-separator",
+            description: "No separator text",
+          },
+        ],
+      )
+    }),
+  )
+
+  it.effect("maps non-2xx responses to RequestFailed errors", () =>
+    Effect.gen(function* () {
+      const { client } = yield* makeClient(
+        () => new Response("boom", { status: 500 }),
+      )
+      const duckDuckGo = yield* DuckDuckGo.make.pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+      )
+
+      const error = yield* duckDuckGo.search("effect").pipe(Effect.flip)
+
+      assert.strictEqual(error._tag, "DuckDuckGoError")
+      assert.strictEqual(error.reason, "RequestFailed")
+    }),
+  )
+
+  it.effect("maps invalid payloads to DecodeFailed errors", () =>
+    Effect.gen(function* () {
+      const { client } = yield* makeClient(
+        () =>
+          new Response("{ not json", {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+            },
+          }),
+      )
+      const duckDuckGo = yield* DuckDuckGo.make.pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+      )
+
+      const error = yield* duckDuckGo.search("effect").pipe(Effect.flip)
+
+      assert.strictEqual(error._tag, "DuckDuckGoError")
+      assert.strictEqual(error.reason, "DecodeFailed")
+    }),
+  )
+})

--- a/src/DuckDuckGo.ts
+++ b/src/DuckDuckGo.ts
@@ -1,0 +1,221 @@
+/**
+ * @since 1.0.0
+ */
+import { Effect, flow, Layer, Schema, ServiceMap } from "effect"
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http"
+
+export const API_URL = "https://api.duckduckgo.com"
+
+const DuckDuckGoSearchResponseSchema = Schema.Struct({
+  Heading: Schema.optional(Schema.String),
+  AbstractText: Schema.optional(Schema.String),
+  AbstractURL: Schema.optional(Schema.String),
+  Results: Schema.optional(Schema.Array(Schema.Unknown)),
+  RelatedTopics: Schema.optional(Schema.Array(Schema.Unknown)),
+})
+
+type DuckDuckGoSearchResponse = typeof DuckDuckGoSearchResponseSchema.Type
+
+export class SearchResult extends Schema.Class<SearchResult>(
+  "clanka/DuckDuckGo/SearchResult",
+)({
+  title: Schema.String,
+  url: Schema.String,
+  description: Schema.String,
+}) {}
+
+export class DuckDuckGoError extends Schema.TaggedErrorClass<DuckDuckGoError>()(
+  "DuckDuckGoError",
+  {
+    reason: Schema.Literals(["RequestFailed", "DecodeFailed"]),
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect),
+  },
+) {}
+
+const requestFailed = (message: string, cause?: unknown) =>
+  new DuckDuckGoError({
+    reason: "RequestFailed",
+    message,
+    ...(cause === undefined ? {} : { cause }),
+  })
+
+const decodeFailed = (message: string, cause?: unknown) =>
+  new DuckDuckGoError({
+    reason: "DecodeFailed",
+    message,
+    ...(cause === undefined ? {} : { cause }),
+  })
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const getNonEmptyString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() !== "" ? value : undefined
+
+const splitSearchText = (
+  text: string,
+): {
+  readonly title: string
+  readonly description: string
+} => {
+  const separator = text.indexOf(" - ")
+  if (separator === -1) {
+    return {
+      title: text,
+      description: text,
+    }
+  }
+
+  const title = text.slice(0, separator).trim()
+  const description = text.slice(separator + 3).trim()
+
+  return {
+    title: title === "" ? text : title,
+    description: description === "" ? text : description,
+  }
+}
+
+const appendResult = (
+  result: SearchResult,
+  seenUrls: Set<string>,
+  results: Array<SearchResult>,
+): void => {
+  if (seenUrls.has(result.url)) {
+    return
+  }
+
+  seenUrls.add(result.url)
+  results.push(result)
+}
+
+const resultFromText = (url: string, text: string): SearchResult => {
+  const parsed = splitSearchText(text)
+  return new SearchResult({
+    title: parsed.title,
+    url,
+    description: parsed.description,
+  })
+}
+
+const appendTopicResults = (
+  topics: ReadonlyArray<unknown>,
+  seenUrls: Set<string>,
+  results: Array<SearchResult>,
+): void => {
+  for (const topic of topics) {
+    if (!isRecord(topic)) {
+      continue
+    }
+
+    const nestedTopics = topic["Topics"]
+    if (Array.isArray(nestedTopics)) {
+      appendTopicResults(nestedTopics, seenUrls, results)
+      continue
+    }
+
+    const text = getNonEmptyString(topic["Text"])
+    const url = getNonEmptyString(topic["FirstURL"])
+    if (text === undefined || url === undefined) {
+      continue
+    }
+
+    appendResult(resultFromText(url, text), seenUrls, results)
+  }
+}
+
+const toSearchResults = (
+  response: DuckDuckGoSearchResponse,
+): Array<SearchResult> => {
+  const results = Array<SearchResult>()
+  const seenUrls = new Set<string>()
+
+  const abstractUrl = getNonEmptyString(response.AbstractURL)
+  if (abstractUrl !== undefined) {
+    const title = getNonEmptyString(response.Heading) ?? abstractUrl
+    const description = getNonEmptyString(response.AbstractText) ?? title
+    appendResult(
+      new SearchResult({
+        title,
+        url: abstractUrl,
+        description,
+      }),
+      seenUrls,
+      results,
+    )
+  }
+
+  if (response.Results !== undefined) {
+    appendTopicResults(response.Results, seenUrls, results)
+  }
+
+  if (response.RelatedTopics !== undefined) {
+    appendTopicResults(response.RelatedTopics, seenUrls, results)
+  }
+
+  return results
+}
+
+export class DuckDuckGo extends ServiceMap.Service<
+  DuckDuckGo,
+  {
+    readonly search: (
+      query: string,
+    ) => Effect.Effect<Array<SearchResult>, DuckDuckGoError>
+  }
+>()("clanka/DuckDuckGo") {
+  static readonly make = Effect.gen(function* () {
+    const httpClient = (yield* HttpClient.HttpClient).pipe(
+      HttpClient.mapRequest(
+        flow(
+          HttpClientRequest.prependUrl(API_URL),
+          HttpClientRequest.acceptJson,
+        ),
+      ),
+      HttpClient.filterStatusOk,
+    )
+
+    const search = Effect.fn("DuckDuckGo.search")(function* (
+      query: string,
+    ): Effect.fn.Return<Array<SearchResult>, DuckDuckGoError> {
+      const normalizedQuery = query.trim()
+      if (normalizedQuery === "") {
+        return []
+      }
+
+      const response = yield* HttpClientRequest.get("/").pipe(
+        HttpClientRequest.setUrlParams({
+          q: normalizedQuery,
+          format: "json",
+          no_html: "1",
+          no_redirect: "1",
+          skip_disambig: "1",
+        }),
+        httpClient.execute,
+        Effect.mapError((cause) =>
+          requestFailed("Failed to execute DuckDuckGo search request", cause),
+        ),
+      )
+
+      const payload = yield* HttpClientResponse.schemaBodyJson(
+        DuckDuckGoSearchResponseSchema,
+      )(response).pipe(
+        Effect.mapError((cause) =>
+          decodeFailed("Failed to decode DuckDuckGo search response", cause),
+        ),
+      )
+
+      return toSearchResults(payload)
+    })
+
+    return DuckDuckGo.of({
+      search,
+    })
+  })
+
+  static readonly layer = Layer.effect(DuckDuckGo, DuckDuckGo.make)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ export * as Copilot from "./Copilot.ts"
 /**
  * @since 1.0.0
  */
+export * as DuckDuckGo from "./DuckDuckGo.ts"
+
+/**
+ * @since 1.0.0
+ */
 export * as Executor from "./Executor.ts"
 
 /**


### PR DESCRIPTION
## Summary

- add a new `DuckDuckGo` Effect service in `src/DuckDuckGo.ts`
- implement `search(query)` returning `Effect.Effect<Array<SearchResult>, DuckDuckGoError>`
- call DuckDuckGo Instant Answer API and normalize/flatten abstract + related topic results with URL deduping
- add typed `SearchResult` and `DuckDuckGoError` models
- export the new module from `src/index.ts`
- add tests in `src/DuckDuckGo.test.ts` for normalization and error mapping
- add one changeset in `.changeset/tiny-parrots-smash.md`

## Validation

- `pnpm check`
- `pnpm test`