### PR TITLE
TIM-719 Allow applyPatch to work without an End marker

### DIFF
--- a/.changeset/olive-carpets-fix.md
+++ b/.changeset/olive-carpets-fix.md
@@ -1,0 +1,5 @@
+---
+"clanka": patch
+---
+
+Allow wrapped applyPatch inputs to succeed when `*** End Patch` is missing at EOF.

--- a/src/AgentTools.test.ts
+++ b/src/AgentTools.test.ts
@@ -248,6 +248,48 @@ describe("AgentTools", () => {
     ),
   )
 
+  it.effect("applies wrapped apply_patch patches without an end marker", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const tempRoot = yield* makeTempRoot("clanka-apply-patch-wrapped-no-end-")
+      yield* fs.makeDirectory(join(tempRoot, "src"), { recursive: true })
+      yield* fs.writeFileString(join(tempRoot, "src", "app.txt"), "old\n")
+
+      const executor = yield* Executor
+      const tools = yield* AgentTools
+      const output = yield* executor
+        .execute({
+          tools,
+          script: [
+            "const output = await applyPatch(`",
+            "*** Begin Patch",
+            "*** Update File: src/app.txt",
+            "@@",
+            "-old",
+            "+new",
+            "`)",
+            "console.log(output)",
+          ].join("\n"),
+        })
+        .pipe(
+          Stream.mkString,
+          Effect.provideServices(makeContextNoop(tempRoot)),
+        )
+
+      expect(output).toContain("M src/app.txt")
+      expect(yield* fs.readFileString(join(tempRoot, "src", "app.txt"))).toBe(
+        "new\n",
+      )
+    }).pipe(
+      Effect.provide([
+        AgentToolHandlers,
+        Executor.layer,
+        ToolkitRenderer.layer,
+      ]),
+      Effect.provide(NodeServices.layer),
+    ),
+  )
+
   it.effect(
     "applies larger wrapped apply_patch patches across multiple files",
     () =>

--- a/src/ApplyPatch.test.ts
+++ b/src/ApplyPatch.test.ts
@@ -28,6 +28,50 @@ describe("patchContent", () => {
     ).toBe("alpha\nbeta\nomega\n")
   })
 
+  it("parses wrapped patches without an end marker at EOF", () => {
+    expect(
+      parsePatch(
+        [
+          "*** Begin Patch",
+          "*** Update File: src/ExaSearch.ts",
+          "@@",
+          " export class ExaSearch extends ServiceMap.Service<",
+          "   ExaSearch,",
+          "   {",
+          "-    search(query: string): Effect.Effect<Array<SearchResponse<{}>>, ExaError>",
+          "+    search(query: string): Effect.Effect<SearchResponse<{}>, ExaError>",
+          "   }",
+          ' >()("clanka/ExaSearch") {}',
+        ].join("\n"),
+      ),
+    ).toEqual([
+      {
+        type: "update",
+        path: "src/ExaSearch.ts",
+        chunks: [
+          {
+            old: [
+              "export class ExaSearch extends ServiceMap.Service<",
+              "  ExaSearch,",
+              "  {",
+              "    search(query: string): Effect.Effect<Array<SearchResponse<{}>>, ExaError>",
+              "  }",
+              '>()("clanka/ExaSearch") {}',
+            ],
+            next: [
+              "export class ExaSearch extends ServiceMap.Service<",
+              "  ExaSearch,",
+              "  {",
+              "    search(query: string): Effect.Effect<SearchResponse<{}>, ExaError>",
+              "  }",
+              '>()("clanka/ExaSearch") {}',
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
   it("parses multi-file wrapped patches", () => {
     expect(
       parsePatch(

--- a/src/ApplyPatch.ts
+++ b/src/ApplyPatch.ts
@@ -55,8 +55,12 @@ const fail = (message: string): never => {
 const locate = (text: string) => {
   const lines = text.split("\n")
   const begin = lines.findIndex((line) => line === BEGIN)
-  const end = lines.findIndex((line) => line === END)
-  if (begin === -1 || end === -1 || begin >= end) {
+  const explicitEnd = lines.findIndex((line) => line === END)
+  if (begin === -1) {
+    fail("Invalid patch format: missing Begin/End markers")
+  }
+  const end = explicitEnd === -1 ? lines.length : explicitEnd
+  if (begin >= end) {
     fail("Invalid patch format: missing Begin/End markers")
   }
   return {


### PR DESCRIPTION
## Summary

- allow wrapped `applyPatch` parsing to succeed when `*** End Patch` is omitted at the bottom of the patch
- keep existing validation behavior for malformed wrapped patches (still requires a valid `*** Begin Patch` and at least one valid section/hunk)
- add regression tests in both parser-level and tool-level suites for missing-end-marker wrapped patches
- add a patch changeset for the behavior fix

## Validation

- `pnpm check`
- `pnpm test`