### PR TITLE
TIM-721 Add concise comment for declare fetch in system prompt

### DIFF
--- a/.changeset/fresh-mugs-prove.md
+++ b/.changeset/fresh-mugs-prove.md
@@ -1,0 +1,5 @@
+---
+"clanka": patch
+---
+
+Add a brief inline comment next to `declare const fetch` in both system prompt variants to clarify that it exposes the global Fetch API for HTTP requests.

--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -561,6 +561,7 @@ You have the following functions available to you:
 \`\`\`ts
 ${toolsDts}
 
+// The global Fetch API available for making HTTP requests.
 declare const fetch: typeof globalThis.fetch
 \`\`\``
 }
@@ -578,6 +579,7 @@ You have the following functions available to you:
 \`\`\`ts
 ${toolsDts}
 
+// The global Fetch API available for making HTTP requests.
 declare const fetch: typeof globalThis.fetch
 \`\`\``
 }

--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -561,7 +561,7 @@ You have the following functions available to you:
 \`\`\`ts
 ${toolsDts}
 
-// The global Fetch API available for making HTTP requests.
+/** The global Fetch API available for making HTTP requests. */
 declare const fetch: typeof globalThis.fetch
 \`\`\``
 }


### PR DESCRIPTION
## Summary
- Added a concise inline comment in both system prompt variants above `declare const fetch: typeof globalThis.fetch`.
- The comment clarifies that this declaration exposes the global Fetch API for HTTP requests.
- Added one changeset for the patch release.

## Validation
- `pnpm check`
- `pnpm test`