### PR TITLE
TIM-724 Remove wrapping code fences before executor

### DIFF
--- a/.changeset/short-kids-nod.md
+++ b/.changeset/short-kids-nod.md
@@ -1,0 +1,5 @@
+---
+"clanka": patch
+---
+
+Strip a single outer markdown code fence before passing generated scripts to the executor, so wrapped JavaScript responses execute directly.

--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -26,6 +26,7 @@ import {
 import { ModelName, ProviderName } from "effect/unstable/ai/Model"
 import { type StreamPart } from "effect/unstable/ai/Response"
 import * as AgentExecutor from "./AgentExecutor.ts"
+import { stripWrappingCodeFence } from "./ScriptExtraction.ts"
 import type { Path } from "effect/Path"
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import type { HttpClient } from "effect/unstable/http/HttpClient"
@@ -279,9 +280,10 @@ ${prompt}`),
 
     const executeScript = Effect.fnUntraced(function* (script: string) {
       maybeSend({ agentId, part: new ScriptEnd(), release: true })
+      const normalizedScript = stripWrappingCodeFence(script)
       const output = yield* pipe(
         executor.execute({
-          script,
+          script: normalizedScript,
           onSubagent: spawnSubagent,
           onTaskComplete: (summary) =>
             Effect.sync(() => {

--- a/src/ScriptExtraction.test.ts
+++ b/src/ScriptExtraction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { extractScript } from "./ScriptExtraction.ts"
+import { extractScript, stripWrappingCodeFence } from "./ScriptExtraction.ts"
 
 describe("extractScript", () => {
   it("returns the full string when there are no code blocks", () => {
@@ -130,5 +130,48 @@ describe("extractScript", () => {
         ["```", "hello", "``` more text", "world", "```"].join("\n"),
       ),
     ).toBe(["hello", "``` more text", "world"].join("\n"))
+  })
+})
+
+describe("stripWrappingCodeFence", () => {
+  it("strips wrapping backtick fences", () => {
+    expect(
+      stripWrappingCodeFence(["```ts", "const answer = 42", "```"].join("\n")),
+    ).toBe("const answer = 42")
+  })
+
+  it("strips wrapping tilde fences", () => {
+    expect(
+      stripWrappingCodeFence(["~~~js", "console.log(1)", "~~~"].join("\n")),
+    ).toBe("console.log(1)")
+  })
+
+  it("preserves CRLF output when stripping wrappers", () => {
+    expect(
+      stripWrappingCodeFence(
+        ["```ts", "const a = 1", "const b = 2", "```"].join("\r\n"),
+      ),
+    ).toBe(["const a = 1", "const b = 2"].join("\r\n"))
+  })
+
+  it("returns the input unchanged when not fully wrapped", () => {
+    const input = [
+      "Some explanation",
+      "",
+      "```ts",
+      "const answer = 42",
+      "```",
+    ].join("\n")
+    expect(stripWrappingCodeFence(input)).toBe(input)
+  })
+
+  it("returns the input unchanged when closing fence is missing", () => {
+    const input = ["```ts", "const answer = 42"].join("\n")
+    expect(stripWrappingCodeFence(input)).toBe(input)
+  })
+
+  it("returns the input unchanged when fence markers do not match", () => {
+    const input = ["```ts", "const answer = 42", "~~~"].join("\n")
+    expect(stripWrappingCodeFence(input)).toBe(input)
   })
 })

--- a/src/ScriptExtraction.ts
+++ b/src/ScriptExtraction.ts
@@ -73,3 +73,53 @@ export const extractScript = (markdown: string): string => {
 
   return blocks.length === 0 ? markdown : blocks.join(separator)
 }
+
+export const stripWrappingCodeFence = (script: string): string => {
+  const lines = script.split(/\r?\n/)
+  if (lines.length < 2) {
+    return script
+  }
+
+  let firstNonEmpty = -1
+  let lastNonEmpty = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]!.trim().length > 0) {
+      firstNonEmpty = i
+      break
+    }
+  }
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i]!.trim().length > 0) {
+      lastNonEmpty = i
+      break
+    }
+  }
+
+  if (
+    firstNonEmpty === -1 ||
+    lastNonEmpty === -1 ||
+    firstNonEmpty >= lastNonEmpty
+  ) {
+    return script
+  }
+
+  const opening = lines[firstNonEmpty]!.match(/^ {0,3}(`{3,}|~{3,})[^\r\n]*$/)
+  if (!opening) {
+    return script
+  }
+
+  const closing = lines[lastNonEmpty]!.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/)
+  if (!closing) {
+    return script
+  }
+
+  if (opening[1]![0] !== closing[1]![0]) {
+    return script
+  }
+  if (closing[1]!.length < opening[1]!.length) {
+    return script
+  }
+
+  const newLine = script.includes("\r\n") ? "\r\n" : "\n"
+  return lines.slice(firstNonEmpty + 1, lastNonEmpty).join(newLine)
+}


### PR DESCRIPTION
## Summary

- normalize generated scripts at the execution boundary by stripping a single outer markdown code fence before calling `AgentExecutor.execute`
- add `stripWrappingCodeFence` in `src/ScriptExtraction.ts` to handle backtick / tilde fences, optional surrounding blank lines, and preserve LF/CRLF line endings
- add focused tests for fence stripping behavior in `src/ScriptExtraction.test.ts` (wrapped scripts, CRLF preservation, and no-op cases for non-wrapped / malformed input)

## Validation

- pnpm check
- pnpm test
