### PR TITLE
TIM-726 Add search tool to AgentTools for subagent-based codebase investigation

### DIFF
--- a/.changeset/tim-726-search-tool.md
+++ b/.changeset/tim-726-search-tool.md
@@ -1,0 +1,7 @@
+---
+"clanka": patch
+---
+
+Add a new `search` AgentTool that spawns a subagent from a textual search description and returns its findings.
+
+The `search` subagent is explicitly instructed not to call `search` recursively, and to return a concise report with file paths, line numbers, and code snippets.

--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -569,9 +569,22 @@ Javascript output:
 const generateSystemMulti = (toolsDts: string) => {
   return `You complete your tasks by **only writing javascript code** to interact with your environment.
 
-- Use \`console.log\` to print any output you need.
+${systemToolsCommon(toolsDts)}`
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any
+const generateSystemSingle = (toolsDts: string) => {
+  return `Use the "execute" tool to run javascript code to do your work.
+
+${systemToolsCommon(toolsDts)}`
+}
+
+const systemToolsCommon = (
+  toolsDts: string,
+) => `- Use \`console.log\` to print any output you need.
 - Top level await is supported.
 - AVOID passing scripts into the "bash" function, and instead write javascript.
+- PREFER the "search" function over "rg" for finding information or code
 
 **When you have fully completed your task**, call the "taskComplete" function with the final output.
 Make sure every detail of the task is done before calling "taskComplete".
@@ -584,25 +597,6 @@ ${toolsDts}
 /** The global Fetch API available for making HTTP requests. */
 declare const fetch: typeof globalThis.fetch
 \`\`\``
-}
-
-// oxlint-disable-next-line typescript/no-explicit-any
-const generateSystemSingle = (toolsDts: string) => {
-  return `Use the "execute" tool to run javascript code to do your work.
-
-- Use \`console.log\` to print any output you need.
-- Top level await is supported.
-- AVOID passing scripts into the "bash" function, and instead write javascript.
-
-You have the following functions available to you:
-
-\`\`\`ts
-${toolsDts}
-
-// The global Fetch API available for making HTTP requests.
-declare const fetch: typeof globalThis.fetch
-\`\`\``
-}
 
 class ScriptExecutor extends ServiceMap.Service<
   ScriptExecutor,

--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -229,10 +229,7 @@ ${content}
         let id = agentCounter++
         const stream = spawn({
           agentId: id,
-          prompt:
-            Prompt.make(`You have been asked using the "delegate" function to complete the following task. Try to avoid using the "delegate" function yourself unless strictly necessary:
-
-${prompt}`),
+          prompt: Prompt.make(prompt),
           system: opts.system,
           disableHistory: true,
         })

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -171,6 +171,15 @@ export const AgentTools = Toolkit.make(
     success: Schema.String,
     dependencies: [SubagentExecutor],
   }),
+  Tool.make("search", {
+    description:
+      "Spawn a subagent to investigate what to find in the codebase. Returns a concise report with file names, line numbers, and code snippets.",
+    parameters: Schema.String.annotate({
+      identifier: "description",
+    }),
+    success: Schema.String,
+    dependencies: [SubagentExecutor],
+  }),
   Tool.make("webSearch", {
     description: "Search the web for recent information.",
     parameters: ExaSearch.ExaSearchOptions,
@@ -516,6 +525,21 @@ export const AgentToolHandlersNoDeps = AgentTools.toLayer(
         yield* Effect.logInfo(`Calling "delegate"`)
         const spawn = yield* SubagentExecutor
         return yield* spawn(prompt)
+      }, Effect.orDie),
+      search: Effect.fn("AgentTools.search")(function* (description) {
+        yield* Effect.logInfo(`Calling "search"`)
+        const spawn = yield* SubagentExecutor
+        return yield* spawn(`You were invoked by the "search" tool to investigate the codebase.
+
+What to find:
+${description}
+
+Requirements:
+- Do not call the "search" tool from this subagent.
+- Use direct inspection tools (like rg, glob, and readFile) to gather evidence.
+- Return a concise report only.
+- Include findings with file names, line numbers, and short code snippets.
+- If nothing relevant is found, say so clearly.`)
       }, Effect.orDie),
       taskComplete: Effect.fn("AgentTools.taskComplete")(function* (message) {
         const deferred = yield* TaskCompleter

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -74,6 +74,14 @@ export const AgentTools = Toolkit.make(
     success: Schema.NullOr(Schema.String),
     dependencies: [CurrentDirectory],
   }),
+  Tool.make("search", {
+    description: "Find information from a description",
+    parameters: Schema.String.annotate({
+      identifier: "description",
+    }),
+    success: Schema.String,
+    dependencies: [SubagentExecutor],
+  }),
   Tool.make("writeFile", {
     description:
       "Write content to a file, creating parent directories if needed. PREFER USING applyPatch to update existing files.",
@@ -124,7 +132,8 @@ export const AgentTools = Toolkit.make(
     dependencies: [CurrentDirectory],
   }),
   Tool.make("rg", {
-    description: "Search for a pattern in files using ripgrep.",
+    description:
+      "Search for a pattern in files using ripgrep. Prefer the search function unless finding something specific",
     parameters: Schema.Struct({
       pattern: Schema.String,
       glob: Schema.optional(Schema.String).annotate({
@@ -167,15 +176,6 @@ export const AgentTools = Toolkit.make(
       "Delegate a task to another software engineer. Returns the result of the task.",
     parameters: Schema.String.annotate({
       identifier: "task",
-    }),
-    success: Schema.String,
-    dependencies: [SubagentExecutor],
-  }),
-  Tool.make("search", {
-    description:
-      "Spawn a subagent to investigate what to find in the codebase. Returns a concise report with file names, line numbers, and code snippets.",
-    parameters: Schema.String.annotate({
-      identifier: "description",
     }),
     success: Schema.String,
     dependencies: [SubagentExecutor],
@@ -524,7 +524,7 @@ export const AgentToolHandlersNoDeps = AgentTools.toLayer(
       delegate: Effect.fn("AgentTools.delegate")(function* (prompt) {
         yield* Effect.logInfo(`Calling "delegate"`)
         const spawn = yield* SubagentExecutor
-        return yield* spawn(`You have been asked using the "delegate" function to complete the following task. Try to avoid using the "delegate" function yourself unless strictly necessary:
+        return yield* spawn(`You have been asked using the "delegate" function to complete the following task. Try to avoid using the "delegate" or "search" functions yourself unless strictly necessary:
 
 ${prompt}`)
       }, Effect.orDie),

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -524,21 +524,20 @@ export const AgentToolHandlersNoDeps = AgentTools.toLayer(
       delegate: Effect.fn("AgentTools.delegate")(function* (prompt) {
         yield* Effect.logInfo(`Calling "delegate"`)
         const spawn = yield* SubagentExecutor
-        return yield* spawn(prompt)
+        return yield* spawn(`You have been asked using the "delegate" function to complete the following task. Try to avoid using the "delegate" function yourself unless strictly necessary:
+
+${prompt}`)
       }, Effect.orDie),
       search: Effect.fn("AgentTools.search")(function* (description) {
         yield* Effect.logInfo(`Calling "search"`)
         const spawn = yield* SubagentExecutor
-        return yield* spawn(`You were invoked by the "search" tool to investigate the codebase.
+        return yield* spawn(`You are to find the following information as fast as possible:
 
-What to find:
 ${description}
 
 Requirements:
-- Do not call the "search" tool from this subagent.
-- Use direct inspection tools (like rg, glob, and readFile) to gather evidence.
-- Return a concise report only.
-- Include findings with file names, line numbers, and short code snippets.
+- DO NOT call the "search" or "delegate" functions.
+- Output a concise report with file names, line numbers, and code snippets.
 - If nothing relevant is found, say so clearly.`)
       }, Effect.orDie),
       taskComplete: Effect.fn("AgentTools.taskComplete")(function* (message) {


### PR DESCRIPTION
## Summary

Implemented TIM-726 by adding a new `search` tool to `AgentTools`.

### What changed

- Added `search` to `src/AgentTools.ts` toolkit registration:
  - Signature: `search(description: string): Promise<string>`
  - Depends on `SubagentExecutor` (same pattern as `delegate`).
- Added `search` handler in `AgentToolHandlersNoDeps`:
  - Spawns a subagent from the provided description.
  - Explicitly instructs the subagent **not** to call `search` recursively.
  - Requires concise findings with **file names, line numbers, and snippets**.
- Added one changeset:
  - `.changeset/tim-726-search-tool.md`

### Validation

- `pnpm check` ✅
- `pnpm test` ✅
