### PR TITLE
TIM-728: Add optional timeout to bash tool options

### DIFF
--- a/.changeset/tall-snakes-jog.md
+++ b/.changeset/tall-snakes-jog.md
@@ -1,0 +1,7 @@
+---
+"clanka": minor
+---
+
+Add an optional `timeout` field to the `bash` tool parameters and change the `bash` tool input shape to `{ command, timeout? }` (with `command` as the parameter name in rendered typings).
+
+The timeout is specified in seconds and defaults to 120 seconds.

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -157,7 +157,12 @@ export const AgentTools = Toolkit.make(
   }),
   Tool.make("bash", {
     description: "Run a bash command and return the output",
-    parameters: Schema.String.annotate({
+    parameters: Schema.Struct({
+      command: Schema.String,
+      timeout: Schema.optional(Schema.Finite).annotate({
+        documentation: "Timeout in seconds (default: 120)",
+      }),
+    }).annotate({
       identifier: "command",
     }),
     success: Schema.String,
@@ -349,16 +354,25 @@ export const AgentToolHandlersNoDeps = AgentTools.toLayer(
         const cwd = yield* CurrentDirectory
         return yield* Effect.promise(() => Glob.glob(pattern, { cwd }))
       }),
-      bash: Effect.fn("AgentTools.bash")(function* (command) {
+      bash: Effect.fn("AgentTools.bash")(function* (options) {
+        const timeout = options.timeout ?? 120
         yield* Effect.logInfo(`Calling "bash"`).pipe(
-          Effect.annotateLogs({ command }),
+          Effect.annotateLogs({ ...options, timeout }),
         )
         const cwd = yield* CurrentDirectory
-        const cmd = ChildProcess.make("bash", ["-c", command], {
+        const cmd = ChildProcess.make("bash", ["-c", options.command], {
           cwd,
           stdin: "ignore",
         })
-        return yield* execute(cmd)
+        return yield* execute(cmd).pipe(
+          Effect.timeoutOrElse({
+            duration: timeout * 1_000,
+            onTimeout: () =>
+              Effect.die(
+                new Error(`Command timed out after ${timeout} seconds`),
+              ),
+          }),
+        )
       }, Effect.orDie),
       gh: Effect.fn("AgentTools.gh")(function* (args) {
         yield* Effect.logInfo(`Calling "gh"`).pipe(

--- a/src/ToolkitRenderer.test.ts
+++ b/src/ToolkitRenderer.test.ts
@@ -1,0 +1,20 @@
+import * as Effect from "effect/Effect"
+import { describe, expect, it } from "vitest"
+import { AgentTools } from "./AgentTools.ts"
+import { ToolkitRenderer } from "./ToolkitRenderer.ts"
+
+describe("ToolkitRenderer", () => {
+  it("renders bash with command options and optional timeout", async () => {
+    const dts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const renderer = yield* ToolkitRenderer
+        return renderer.render(AgentTools)
+      }).pipe(Effect.provide(ToolkitRenderer.layer)),
+    )
+
+    expect(dts).toContain("declare function bash(command: {")
+    expect(dts).toContain("readonly command: string;")
+    expect(dts).toContain("readonly timeout?: number | undefined;")
+    expect(dts).toContain("Timeout in seconds (default: 120)")
+  })
+})


### PR DESCRIPTION
## Summary

- changed the `bash` tool parameters from a string to an options object: `{ command, timeout? }`
- kept the rendered parameter name as `command` in generated tool typings
- added optional `timeout` in seconds with a default of `120` seconds
- enforced timeout handling in the `bash` handler with a clear timeout error message
- added a regression test in `src/ToolkitRenderer.test.ts` to verify the rendered `bash` signature and timeout docs
- added one changeset: `.changeset/tall-snakes-jog.md`

## Validation

- `pnpm check`
- `pnpm test`