### PR TITLE
TIM-733: Replace SemanticSearch.reindex with file-scoped indexing methods

### DIFF
--- a/.changeset/tiny-tables-tease.md
+++ b/.changeset/tiny-tables-tease.md
@@ -1,0 +1,10 @@
+---
+"clanka": minor
+---
+
+Replace `SemanticSearch.reindex` with file-specific index update methods.
+
+- Add `SemanticSearch.updateFile(path)` to re-chunk and re-embed a single file.
+- Add `SemanticSearch.removeFile(path)` to remove a single file from the index.
+- Add `CodeChunker.chunkFile` and `CodeChunker.chunkFiles` for targeted chunking.
+- Update `AgentTools` file mutation handlers to call targeted semantic index updates instead of global reindexing.

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -295,14 +295,16 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
           recursive: true,
         })
         yield* fs.writeFileString(path, options.content)
-        yield* SemanticSearch.maybeReindex
+        yield* SemanticSearch.maybeUpdateFile(path)
       }, Effect.orDie),
       removeFile: Effect.fn("AgentTools.removeFile")(function* (path) {
         yield* Effect.logInfo(`Calling "removeFile"`).pipe(
           Effect.annotateLogs({ path }),
         )
         const cwd = yield* CurrentDirectory
-        return yield* fs.remove(pathService.resolve(cwd, path), { force: true })
+        const absolutePath = pathService.resolve(cwd, path)
+        yield* fs.remove(absolutePath, { force: true })
+        yield* SemanticSearch.maybeRemoveFile(absolutePath)
       }, Effect.orDie),
       renameFile: Effect.fn("AgentTools.renameFile")(function* (options) {
         yield* Effect.logInfo(`Calling "renameFile"`).pipe(
@@ -314,7 +316,9 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
         yield* fs.makeDirectory(pathService.dirname(to), {
           recursive: true,
         })
-        return yield* fs.rename(from, to)
+        yield* fs.rename(from, to)
+        yield* SemanticSearch.maybeRemoveFile(from)
+        yield* SemanticSearch.maybeUpdateFile(to)
       }, Effect.orDie),
       mkdir: Effect.fn("AgentTools.mkdir")(function* (path) {
         yield* Effect.logInfo(`Calling "mkdir"`).pipe(
@@ -545,6 +549,7 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
                 recursive: true,
               })
               yield* fs.writeFileString(step.path, step.next)
+              yield* SemanticSearch.maybeUpdateFile(step.path)
               break
             }
             case "move": {
@@ -553,16 +558,17 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
               })
               yield* fs.writeFileString(step.movePath, step.next)
               yield* fs.remove(step.path)
+              yield* SemanticSearch.maybeRemoveFile(step.path)
+              yield* SemanticSearch.maybeUpdateFile(step.movePath)
               break
             }
             case "delete": {
               yield* fs.remove(step.path)
+              yield* SemanticSearch.maybeRemoveFile(step.path)
               break
             }
           }
         }
-
-        yield* SemanticSearch.maybeReindex
 
         return `Success. Updated the following files:\n${out.join("\n")}`
       }, Effect.orDie),

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -295,7 +295,9 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
           recursive: true,
         })
         yield* fs.writeFileString(path, options.content)
-        yield* SemanticSearch.maybeUpdateFile(path)
+        yield* SemanticSearch.maybeUpdateFile(
+          pathService.relative(cwd, path).replaceAll("\\", "/"),
+        )
       }, Effect.orDie),
       removeFile: Effect.fn("AgentTools.removeFile")(function* (path) {
         yield* Effect.logInfo(`Calling "removeFile"`).pipe(
@@ -304,7 +306,9 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
         const cwd = yield* CurrentDirectory
         const absolutePath = pathService.resolve(cwd, path)
         yield* fs.remove(absolutePath, { force: true })
-        yield* SemanticSearch.maybeRemoveFile(absolutePath)
+        yield* SemanticSearch.maybeRemoveFile(
+          pathService.relative(cwd, absolutePath).replaceAll("\\", "/"),
+        )
       }, Effect.orDie),
       renameFile: Effect.fn("AgentTools.renameFile")(function* (options) {
         yield* Effect.logInfo(`Calling "renameFile"`).pipe(
@@ -317,8 +321,12 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
           recursive: true,
         })
         yield* fs.rename(from, to)
-        yield* SemanticSearch.maybeRemoveFile(from)
-        yield* SemanticSearch.maybeUpdateFile(to)
+        yield* SemanticSearch.maybeRemoveFile(
+          pathService.relative(cwd, from).replaceAll("\\", "/"),
+        )
+        yield* SemanticSearch.maybeUpdateFile(
+          pathService.relative(cwd, to).replaceAll("\\", "/"),
+        )
       }, Effect.orDie),
       mkdir: Effect.fn("AgentTools.mkdir")(function* (path) {
         yield* Effect.logInfo(`Calling "mkdir"`).pipe(
@@ -549,7 +557,7 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
                 recursive: true,
               })
               yield* fs.writeFileString(step.path, step.next)
-              yield* SemanticSearch.maybeUpdateFile(step.path)
+              yield* SemanticSearch.maybeUpdateFile(rel(step.path))
               break
             }
             case "move": {
@@ -558,13 +566,13 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
               })
               yield* fs.writeFileString(step.movePath, step.next)
               yield* fs.remove(step.path)
-              yield* SemanticSearch.maybeRemoveFile(step.path)
-              yield* SemanticSearch.maybeUpdateFile(step.movePath)
+              yield* SemanticSearch.maybeRemoveFile(rel(step.path))
+              yield* SemanticSearch.maybeUpdateFile(rel(step.movePath))
               break
             }
             case "delete": {
               yield* fs.remove(step.path)
-              yield* SemanticSearch.maybeRemoveFile(step.path)
+              yield* SemanticSearch.maybeRemoveFile(rel(step.path))
               break
             }
           }

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -295,9 +295,7 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
           recursive: true,
         })
         yield* fs.writeFileString(path, options.content)
-        yield* SemanticSearch.maybeUpdateFile(
-          pathService.relative(cwd, path).replaceAll("\\", "/"),
-        )
+        yield* SemanticSearch.maybeUpdateFile(pathService.relative(cwd, path))
       }, Effect.orDie),
       removeFile: Effect.fn("AgentTools.removeFile")(function* (path) {
         yield* Effect.logInfo(`Calling "removeFile"`).pipe(
@@ -307,7 +305,7 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
         const absolutePath = pathService.resolve(cwd, path)
         yield* fs.remove(absolutePath, { force: true })
         yield* SemanticSearch.maybeRemoveFile(
-          pathService.relative(cwd, absolutePath).replaceAll("\\", "/"),
+          pathService.relative(cwd, absolutePath),
         )
       }, Effect.orDie),
       renameFile: Effect.fn("AgentTools.renameFile")(function* (options) {
@@ -321,12 +319,8 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
           recursive: true,
         })
         yield* fs.rename(from, to)
-        yield* SemanticSearch.maybeRemoveFile(
-          pathService.relative(cwd, from).replaceAll("\\", "/"),
-        )
-        yield* SemanticSearch.maybeUpdateFile(
-          pathService.relative(cwd, to).replaceAll("\\", "/"),
-        )
+        yield* SemanticSearch.maybeRemoveFile(pathService.relative(cwd, from))
+        yield* SemanticSearch.maybeUpdateFile(pathService.relative(cwd, to))
       }, Effect.orDie),
       mkdir: Effect.fn("AgentTools.mkdir")(function* (path) {
         yield* Effect.logInfo(`Calling "mkdir"`).pipe(
@@ -470,8 +464,7 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
             }
         >
         const out = [] as Array<string>
-        const rel = (path: string) =>
-          pathService.relative(cwd, path).replaceAll("\\", "/")
+        const rel = (path: string) => pathService.relative(cwd, path)
         const load = Effect.fn("AgentTools.applyPatch.load")(function* (
           path: string,
           reason: "delete" | "update",

--- a/src/ChunkRepo.ts
+++ b/src/ChunkRepo.ts
@@ -126,6 +126,7 @@ export class ChunkRepo extends ServiceMap.Service<
       chunkId: ChunkId,
       syncId: SyncId,
     ): Effect.Effect<void, ChunkRepoError>
+    deleteByPath(path: string): Effect.Effect<void, ChunkRepoError>
     deleteForSyncId(syncId: SyncId): Effect.Effect<void, ChunkRepoError>
   }
 >()("clanka/ChunkRepo") {}
@@ -221,6 +222,10 @@ export const layer = Layer.effect(
       quantize: maybeQuantize,
       setSyncId: (chunkId, syncId) =>
         sql`update chunks set syncId = ${syncId} where id = ${chunkId}`.pipe(
+          Effect.mapError((reason) => new ChunkRepoError({ reason })),
+        ),
+      deleteByPath: (path) =>
+        sql`delete from chunks where path = ${path}`.pipe(
           Effect.mapError((reason) => new ChunkRepoError({ reason })),
         ),
       deleteForSyncId: (syncId) =>

--- a/src/CodeChunker.ts
+++ b/src/CodeChunker.ts
@@ -36,6 +36,18 @@ export class CodeChunker extends ServiceMap.Service<
       readonly root: string
       readonly maxFileSize?: string | undefined
     }): Effect.Effect<ReadonlyArray<string>>
+    chunkFile(options: {
+      readonly root: string
+      readonly path: string
+      readonly chunkSize: number
+      readonly chunkOverlap: number
+    }): Effect.Effect<ReadonlyArray<CodeChunk>>
+    chunkFiles(options: {
+      readonly root: string
+      readonly paths: ReadonlyArray<string>
+      readonly chunkSize: number
+      readonly chunkOverlap: number
+    }): Stream.Stream<CodeChunk>
     chunkCodebase(options: {
       readonly root: string
       readonly maxFileSize?: string | undefined
@@ -346,6 +358,46 @@ export const layer: Layer.Layer<
       )
     })
 
+    const chunkFile: CodeChunker["Service"]["chunkFile"] = Effect.fn(
+      "CodeChunker.chunkFile",
+    )(function* (options): Effect.fn.Return<ReadonlyArray<CodeChunk>> {
+      const root = pathService.resolve(options.root)
+      const absolutePath = pathService.resolve(root, options.path)
+      const path = normalizePath(pathService.relative(root, absolutePath))
+
+      if (
+        path.length === 0 ||
+        path === ".." ||
+        path.startsWith("../") ||
+        !isMeaningfulFile(path)
+      ) {
+        return []
+      }
+
+      return yield* pipe(
+        fs.readFileString(absolutePath),
+        Effect.map((content) => chunkFileContent(path, content, options)),
+        Effect.catch(() => Effect.succeed([])),
+      )
+    })
+
+    const chunkFiles: CodeChunker["Service"]["chunkFiles"] = (options) =>
+      Stream.fromArray(options.paths).pipe(
+        Stream.flatMap(
+          (path) =>
+            pipe(
+              chunkFile({
+                root: options.root,
+                path,
+                chunkSize: options.chunkSize,
+                chunkOverlap: options.chunkOverlap,
+              }),
+              Stream.fromArrayEffect,
+            ),
+          { concurrency: 5 },
+        ),
+      )
+
     const chunkCodebase: CodeChunker["Service"]["chunkCodebase"] =
       Effect.fnUntraced(function* (options) {
         const root = pathService.resolve(options.root)
@@ -356,26 +408,18 @@ export const layer: Layer.Layer<
             : { maxFileSize: options.maxFileSize }),
         })
 
-        return Stream.fromArray(files).pipe(
-          Stream.flatMap(
-            (path) => {
-              const absolutePath = pathService.resolve(root, path)
-              return pipe(
-                fs.readFileString(absolutePath),
-                Effect.map((content) =>
-                  chunkFileContent(path, content, options),
-                ),
-                Effect.catch(() => Effect.succeed([])),
-                Stream.fromArrayEffect,
-              )
-            },
-            { concurrency: 5 },
-          ),
-        )
+        return chunkFiles({
+          root,
+          paths: files,
+          chunkSize: options.chunkSize,
+          chunkOverlap: options.chunkOverlap,
+        })
       }, Stream.unwrap)
 
     return CodeChunker.of({
       listFiles,
+      chunkFile,
+      chunkFiles,
       chunkCodebase,
     })
   }),

--- a/src/SemanticSearch.ts
+++ b/src/SemanticSearch.ts
@@ -10,7 +10,7 @@ import { pipe } from "effect/Function"
 import * as EmbeddingModel from "effect/unstable/ai/EmbeddingModel"
 import * as RequestResolver from "effect/RequestResolver"
 import * as Option from "effect/Option"
-import type * as Path from "effect/Path"
+import * as Path from "effect/Path"
 import * as ServiceMap from "effect/ServiceMap"
 import * as Fiber from "effect/Fiber"
 import * as Duration from "effect/Duration"
@@ -23,6 +23,13 @@ import type * as ChildProcessSpawner from "effect/unstable/process/ChildProcessS
 import type * as FileSystem from "effect/FileSystem"
 import * as Console from "effect/Console"
 
+const normalizePath = (path: string) => path.replace(/\\/g, "/")
+
+const chunkConfig = {
+  chunkSize: 20,
+  chunkOverlap: 5,
+} as const
+
 /**
  * @since 1.0.0
  * @category Services
@@ -34,7 +41,8 @@ export class SemanticSearch extends ServiceMap.Service<
       readonly query: string
       readonly limit: number
     }): Effect.Effect<string>
-    readonly reindex: Effect.Effect<void>
+    updateFile(path: string): Effect.Effect<void>
+    removeFile(path: string): Effect.Effect<void>
   }
 >()("clanka/SemanticSearch/SemanticSearch") {}
 
@@ -65,14 +73,82 @@ export const layer = (options: {
       const chunker = yield* CodeChunker.CodeChunker
       const repo = yield* ChunkRepo.ChunkRepo
       const embeddings = yield* EmbeddingModel.EmbeddingModel
+      const pathService = yield* Path.Path
+      const root = pathService.resolve(options.directory)
       const resolver = embeddings.resolver.pipe(
         RequestResolver.setDelay(
           options.embeddingBatchSize ?? Duration.millis(50),
         ),
         RequestResolver.batchN(options.embeddingBatchSize ?? 500),
       )
+      const concurrency = options.concurrency ?? 2000
       const indexHandle = yield* FiberHandle.make()
       const console = yield* Console.Console
+
+      const resolveIndexedPath = (path: string): Option.Option<string> => {
+        const absolutePath = pathService.resolve(root, path)
+        const relativePath = normalizePath(
+          pathService.relative(root, absolutePath),
+        )
+        if (
+          relativePath.length === 0 ||
+          relativePath === ".." ||
+          relativePath.startsWith("../")
+        ) {
+          return Option.none()
+        }
+        return Option.some(relativePath)
+      }
+
+      const processChunk = Effect.fnUntraced(
+        function* (options: {
+          readonly chunk: CodeChunker.CodeChunk
+          readonly syncId: ChunkRepo.SyncId
+          readonly checkExisting: boolean
+        }) {
+          if (options.checkExisting) {
+            const id = yield* repo.exists({
+              path: options.chunk.path,
+              startLine: options.chunk.startLine,
+              hash: options.chunk.contentHash,
+            })
+            if (Option.isSome(id)) {
+              yield* repo.setSyncId(id.value, options.syncId)
+              return
+            }
+          }
+
+          const result = yield* Effect.request(
+            new EmbeddingModel.EmbeddingRequest({
+              input: `File: ${options.chunk.path}
+Lines: ${options.chunk.startLine}-${options.chunk.endLine}
+
+${options.chunk.content}`,
+            }),
+            resolver,
+          )
+          const vector = new Float32Array(result.vector)
+          yield* repo.insert(
+            ChunkRepo.Chunk.insert.makeUnsafe({
+              path: options.chunk.path,
+              startLine: options.chunk.startLine,
+              endLine: options.chunk.endLine,
+              hash: options.chunk.contentHash,
+              content: options.chunk.content,
+              vector,
+              syncId: options.syncId,
+            }),
+          )
+        },
+        Effect.ignore({
+          log: "Warn",
+          message: "Failed to process chunk for embedding",
+        }),
+        (effect, options) =>
+          Effect.annotateLogs(effect, {
+            chunk: `${options.chunk.path}/${options.chunk.startLine}`,
+          }),
+      )
 
       const index = Effect.gen(function* () {
         const syncId = ChunkRepo.SyncId.makeUnsafe(crypto.randomUUID())
@@ -80,57 +156,22 @@ export const layer = (options: {
 
         yield* pipe(
           chunker.chunkCodebase({
-            root: options.directory,
-            chunkSize: 20,
-            chunkOverlap: 5,
+            root,
+            ...chunkConfig,
           }),
           Stream.tap(
-            Effect.fnUntraced(
-              function* (chunk) {
-                const id = yield* repo.exists({
-                  path: chunk.path,
-                  startLine: chunk.startLine,
-                  hash: chunk.contentHash,
-                })
-                if (Option.isSome(id)) {
-                  yield* repo.setSyncId(id.value, syncId)
-                  return
-                }
-                const result = yield* Effect.request(
-                  new EmbeddingModel.EmbeddingRequest({
-                    input: `File: ${chunk.path}
-Lines: ${chunk.startLine}-${chunk.endLine}
-
-${chunk.content}`,
-                  }),
-                  resolver,
-                )
-                const vector = new Float32Array(result.vector)
-                yield* repo.insert(
-                  ChunkRepo.Chunk.insert.makeUnsafe({
-                    path: chunk.path,
-                    startLine: chunk.startLine,
-                    endLine: chunk.endLine,
-                    hash: chunk.contentHash,
-                    content: chunk.content,
-                    vector,
-                    syncId,
-                  }),
-                )
-              },
-              Effect.ignore({
-                log: "Warn",
-                message: "Failed to process chunk for embedding",
+            (chunk) =>
+              processChunk({
+                chunk,
+                syncId,
+                checkExisting: true,
               }),
-              (effect, chunk) =>
-                Effect.annotateLogs(effect, {
-                  chunk: `${chunk.path}/${chunk.startLine}`,
-                }),
-            ),
-            { concurrency: options.concurrency ?? 2000 },
+            { concurrency },
           ),
           Stream.runDrain,
         )
+
+        yield* repo.deleteForSyncId(syncId)
 
         yield* Effect.logInfo("Finished SemanticSearch index")
       }).pipe(
@@ -161,7 +202,48 @@ ${chunk.content}`,
           })
           return results.map((r) => r.format()).join("\n\n")
         }, Effect.orDie),
-        reindex: Effect.asVoid(runIndex),
+        updateFile: Effect.fn("SemanticSearch.updateFile")(function* (path) {
+          yield* Fiber.join(initialIndex)
+          const indexedPath = resolveIndexedPath(path)
+          if (Option.isNone(indexedPath)) {
+            return
+          }
+
+          yield* repo.deleteByPath(indexedPath.value)
+
+          const chunks = yield* chunker.chunkFile({
+            root,
+            path: indexedPath.value,
+            ...chunkConfig,
+          })
+          if (chunks.length === 0) {
+            return
+          }
+
+          const syncId = ChunkRepo.SyncId.makeUnsafe(crypto.randomUUID())
+
+          yield* pipe(
+            Stream.fromArray(chunks),
+            Stream.tap(
+              (chunk) =>
+                processChunk({
+                  chunk,
+                  syncId,
+                  checkExisting: false,
+                }),
+              { concurrency },
+            ),
+            Stream.runDrain,
+          )
+        }, Effect.orDie),
+        removeFile: Effect.fn("SemanticSearch.removeFile")(function* (path) {
+          yield* Fiber.join(initialIndex)
+          const indexedPath = resolveIndexedPath(path)
+          if (Option.isNone(indexedPath)) {
+            return
+          }
+          yield* repo.deleteByPath(indexedPath.value)
+        }, Effect.orDie),
       })
     }),
   ).pipe(
@@ -177,13 +259,26 @@ ${chunk.content}`,
  * @since 1.0.0
  * @category Utils
  */
-export const maybeReindex: Effect.Effect<void> = Effect.serviceOption(
-  SemanticSearch,
-).pipe(
-  Effect.flatMap(
-    Option.match({
-      onNone: () => Effect.void,
-      onSome: (service) => service.reindex,
-    }),
-  ),
-)
+export const maybeUpdateFile = (path: string): Effect.Effect<void> =>
+  Effect.serviceOption(SemanticSearch).pipe(
+    Effect.flatMap(
+      Option.match({
+        onNone: () => Effect.void,
+        onSome: (service) => service.updateFile(path),
+      }),
+    ),
+  )
+
+/**
+ * @since 1.0.0
+ * @category Utils
+ */
+export const maybeRemoveFile = (path: string): Effect.Effect<void> =>
+  Effect.serviceOption(SemanticSearch).pipe(
+    Effect.flatMap(
+      Option.match({
+        onNone: () => Effect.void,
+        onSome: (service) => service.removeFile(path),
+      }),
+    ),
+  )


### PR DESCRIPTION
## Summary
- replace `SemanticSearch.reindex` with targeted `updateFile(path)` and `removeFile(path)` methods
- add `CodeChunker.chunkFile` and `CodeChunker.chunkFiles` to support chunking specific file paths
- update `AgentTools` file mutation handlers (`writeFile`, `removeFile`, `renameFile`, `applyPatch`) to keep semantic index in sync using targeted updates
- pass relative paths from AgentTools into semantic index update/remove calls to match the search root contract
- ensure full index sweeps stale chunks by deleting records from previous sync ids

## Validation
- `pnpm check`
- `pnpm test`
