### PR TITLE
TIM-740: honor embeddingRequestDelay in SemanticSearch resolver

### DIFF
--- a/.changeset/gold-rabbits-visit.md
+++ b/.changeset/gold-rabbits-visit.md
@@ -1,0 +1,5 @@
+---
+"clanka": patch
+---
+
+Fix SemanticSearch embedding resolver wiring so `embeddingRequestDelay` controls `RequestResolver.setDelay` (defaulting to 50ms), instead of incorrectly deriving delay from `embeddingBatchSize`. Add regression tests for explicit and default delay behavior.

--- a/src/SemanticSearch.test.ts
+++ b/src/SemanticSearch.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import * as Duration from "effect/Duration"
+import * as Effect from "effect/Effect"
+import * as RequestResolver from "effect/RequestResolver"
+import type * as EmbeddingModel from "effect/unstable/ai/EmbeddingModel"
+import { makeEmbeddingResolver } from "./SemanticSearch.ts"
+
+const baseResolver = RequestResolver.make<EmbeddingModel.EmbeddingRequest>(
+  () => Effect.void,
+)
+
+describe("SemanticSearch.makeEmbeddingResolver", () => {
+  it("uses embeddingRequestDelay instead of embeddingBatchSize", async () => {
+    const resolver = makeEmbeddingResolver(baseResolver, {
+      embeddingBatchSize: 1,
+      embeddingRequestDelay: Duration.millis(200),
+    })
+
+    const [duration] = await Effect.runPromise(Effect.timed(resolver.delay))
+
+    expect(Duration.toMillis(duration)).toBeGreaterThanOrEqual(150)
+  })
+
+  it("defaults delay to 50ms regardless of batch size", async () => {
+    const resolver = makeEmbeddingResolver(baseResolver, {
+      embeddingBatchSize: 999,
+    })
+
+    const [duration] = await Effect.runPromise(Effect.timed(resolver.delay))
+    const millis = Duration.toMillis(duration)
+
+    expect(millis).toBeGreaterThanOrEqual(20)
+    expect(millis).toBeLessThan(800)
+  })
+})

--- a/src/SemanticSearch.test.ts
+++ b/src/SemanticSearch.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest"
+import { assert, describe, it } from "@effect/vitest"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
+import * as Fiber from "effect/Fiber"
 import * as RequestResolver from "effect/RequestResolver"
+import { TestClock } from "effect/testing"
 import type * as EmbeddingModel from "effect/unstable/ai/EmbeddingModel"
 import { makeEmbeddingResolver } from "./SemanticSearch.ts"
 
@@ -10,26 +12,40 @@ const baseResolver = RequestResolver.make<EmbeddingModel.EmbeddingRequest>(
 )
 
 describe("SemanticSearch.makeEmbeddingResolver", () => {
-  it("uses embeddingRequestDelay instead of embeddingBatchSize", async () => {
-    const resolver = makeEmbeddingResolver(baseResolver, {
-      embeddingBatchSize: 1,
-      embeddingRequestDelay: Duration.millis(200),
-    })
+  it.effect("uses embeddingRequestDelay instead of embeddingBatchSize", () =>
+    Effect.gen(function* () {
+      const resolver = makeEmbeddingResolver(baseResolver, {
+        embeddingBatchSize: 1,
+        embeddingRequestDelay: Duration.millis(200),
+      })
 
-    const [duration] = await Effect.runPromise(Effect.timed(resolver.delay))
+      const fiber = yield* Effect.forkChild(resolver.delay)
 
-    expect(Duration.toMillis(duration)).toBeGreaterThanOrEqual(150)
-  })
+      yield* TestClock.adjust(Duration.millis(199))
+      assert.strictEqual(fiber.pollUnsafe(), undefined)
 
-  it("defaults delay to 50ms regardless of batch size", async () => {
-    const resolver = makeEmbeddingResolver(baseResolver, {
-      embeddingBatchSize: 999,
-    })
+      yield* TestClock.adjust(Duration.millis(1))
+      assert.notStrictEqual(fiber.pollUnsafe(), undefined)
 
-    const [duration] = await Effect.runPromise(Effect.timed(resolver.delay))
-    const millis = Duration.toMillis(duration)
+      yield* Fiber.join(fiber)
+    }),
+  )
 
-    expect(millis).toBeGreaterThanOrEqual(20)
-    expect(millis).toBeLessThan(800)
-  })
+  it.effect("defaults delay to 50ms regardless of batch size", () =>
+    Effect.gen(function* () {
+      const resolver = makeEmbeddingResolver(baseResolver, {
+        embeddingBatchSize: 999,
+      })
+
+      const fiber = yield* Effect.forkChild(resolver.delay)
+
+      yield* TestClock.adjust(Duration.millis(49))
+      assert.strictEqual(fiber.pollUnsafe(), undefined)
+
+      yield* TestClock.adjust(Duration.millis(1))
+      assert.notStrictEqual(fiber.pollUnsafe(), undefined)
+
+      yield* Fiber.join(fiber)
+    }),
+  )
 })

--- a/src/SemanticSearch.ts
+++ b/src/SemanticSearch.ts
@@ -46,6 +46,20 @@ export class SemanticSearch extends ServiceMap.Service<
   }
 >()("clanka/SemanticSearch/SemanticSearch") {}
 
+export const makeEmbeddingResolver = (
+  resolver: EmbeddingModel.Service["resolver"],
+  options: {
+    readonly embeddingBatchSize?: number | undefined
+    readonly embeddingRequestDelay?: Duration.Input | undefined
+  },
+): EmbeddingModel.Service["resolver"] =>
+  resolver.pipe(
+    RequestResolver.setDelay(
+      options.embeddingRequestDelay ?? Duration.millis(50),
+    ),
+    RequestResolver.batchN(options.embeddingBatchSize ?? 500),
+  )
+
 /**
  * @since 1.0.0
  * @category Layers
@@ -75,12 +89,7 @@ export const layer = (options: {
       const embeddings = yield* EmbeddingModel.EmbeddingModel
       const pathService = yield* Path.Path
       const root = pathService.resolve(options.directory)
-      const resolver = embeddings.resolver.pipe(
-        RequestResolver.setDelay(
-          options.embeddingBatchSize ?? Duration.millis(50),
-        ),
-        RequestResolver.batchN(options.embeddingBatchSize ?? 500),
-      )
+      const resolver = makeEmbeddingResolver(embeddings.resolver, options)
       const concurrency = options.concurrency ?? 2000
       const indexHandle = yield* FiberHandle.make()
       const console = yield* Console.Console


### PR DESCRIPTION
## Summary
- fix SemanticSearch resolver wiring so request delay uses `embeddingRequestDelay` (defaulting to 50ms)
- keep batch sizing controlled by `embeddingBatchSize`
- add regression coverage in `src/SemanticSearch.test.ts` for explicit delay overrides and default-delay behavior
- add a changeset for this patch release

## Validation
- `pnpm check`
- `pnpm test`
