### PR TITLE
TIM-742 Add smart script pre-processing for common backtick mistakes

### DIFF
--- a/.changeset/tall-horns-move.md
+++ b/.changeset/tall-horns-move.md
@@ -1,0 +1,5 @@
+---
+"clanka": patch
+---
+
+add script pre-processing fallback that escapes unescaped backticks in applyPatch, writeFile, and taskComplete template arguments before execution

--- a/src/AgentExecutor.ts
+++ b/src/AgentExecutor.ts
@@ -38,6 +38,7 @@ import * as RpcGroup from "effect/unstable/rpc/RpcGroup"
 import * as Rpc from "effect/unstable/rpc/Rpc"
 import * as Result from "effect/Result"
 import { SemanticSearch } from "./SemanticSearch.ts"
+import { preprocessScript } from "./ScriptPreprocessing.ts"
 import * as References from "effect/References"
 
 /**
@@ -144,9 +145,7 @@ export const makeLocal = Effect.fnUntraced(function* <
       const console = yield* Console.Console
       let running = 0
 
-      const vmScript = new NodeVm.Script(`async function main() {
-${opts.script}
-}`)
+      const vmScript = compileScript(opts.script)
       const sandbox: ScriptSandbox = {
         main: defaultMain,
         console,
@@ -431,6 +430,31 @@ interface ScriptSandbox {
   main: () => Promise<void>
   console: Console.Console
   [toolName: string]: unknown
+}
+
+const wrapScript = (script: string): string => `async function main() {
+${script}
+}`
+
+const compileScript = (script: string): NodeVm.Script => {
+  try {
+    return new NodeVm.Script(wrapScript(script))
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      throw error
+    }
+
+    const preprocessed = preprocessScript(script)
+    if (preprocessed === script) {
+      throw error
+    }
+
+    try {
+      return new NodeVm.Script(wrapScript(preprocessed))
+    } catch {
+      throw error
+    }
+  }
 }
 
 const defaultMain = () => Promise.resolve()

--- a/src/CodeChunker.test.ts
+++ b/src/CodeChunker.test.ts
@@ -5,6 +5,7 @@ import {
   isProbablyMinified,
 } from "./CodeChunker.ts"
 import { readFileSync } from "node:fs"
+import { join } from "node:path"
 
 describe("isMeaningfulFile", () => {
   it("keeps source and documentation files", () => {
@@ -322,7 +323,7 @@ describe("chunkFileContent", () => {
 
   it("seperates class methods into their own chunks", () => {
     const fixture = readFileSync(
-      "/Volumes/Code/effect/effect-smol/packages/effect/src/internal/effect.ts",
+      join(__dirname, "fixtures", "fiber.txt"),
       "utf-8",
     )
     const chunks = chunkFileContent("src/fiber.ts", fixture, {

--- a/src/ScriptPreprocessing.test.ts
+++ b/src/ScriptPreprocessing.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 
 const tick = "`"
 const escaped = "\\`"
+const escapedInterpolation = "\\${"
 const wrapTemplate = (value: string): string => `${tick}${value}${tick}`
 
 describe("preprocessScript", () => {
@@ -28,6 +29,25 @@ describe("preprocessScript", () => {
     )
     assert.strictEqual(
       output.includes(`+const newValue = ${escaped}new${escaped}`),
+      true,
+    )
+  })
+
+  it("escapes internal interpolations in applyPatch templates", () => {
+    const input = [
+      "await applyPatch(`",
+      "*** Begin Patch",
+      "*** Update File: src/example.ts",
+      "@@",
+      "+const value = ${nextValue}",
+      "*** End Patch",
+      "`)",
+    ].join("\n")
+
+    const output = preprocessScript(input)
+
+    assert.strictEqual(
+      output.includes(`+const value = ${escapedInterpolation}nextValue}`),
       true,
     )
   })
@@ -64,6 +84,7 @@ describe("preprocessScript", () => {
   it("does not change scripts when target templates are already escaped", () => {
     const input = [
       `await applyPatch(${wrapTemplate(`const value = ${escaped}safe${escaped}`)})`,
+      `await applyPatch(${wrapTemplate(`const value = ${escapedInterpolation}safe}`)})`,
       `await writeFile({ path: "src/example.ts", content: ${wrapTemplate(`already ${escaped}safe${escaped}`)} })`,
       `await taskComplete(${wrapTemplate(`All done with ${escaped}safe${escaped} backticks.`)})`,
     ].join("\n")
@@ -75,6 +96,65 @@ describe("preprocessScript", () => {
     const input = "await otherTool(`Keep `this` untouched.`)"
 
     assert.strictEqual(preprocessScript(input), input)
+  })
+
+  it("escapes internal backticks in applyPatch templates assigned to variables", () => {
+    const input = [
+      "const patch = `*** Begin Patch",
+      "*** Update File: src/example.ts",
+      "@@",
+      "-const oldValue = `old`",
+      "+const newValue = `new`",
+      "*** End Patch`;",
+      "await applyPatch(patch)",
+    ].join("\n")
+
+    const output = preprocessScript(input)
+
+    assert.strictEqual(
+      output.includes(`-const oldValue = ${escaped}old${escaped}`),
+      true,
+    )
+    assert.strictEqual(
+      output.includes(`+const newValue = ${escaped}new${escaped}`),
+      true,
+    )
+  })
+
+  it("escapes internal backticks in taskComplete templates assigned to variables", () => {
+    const input = [
+      "const summary = `Implemented `TypeBuilder` updates.`;",
+      "await taskComplete(summary)",
+    ].join("\n")
+
+    const output = preprocessScript(input)
+
+    assert.strictEqual(
+      output,
+      [
+        `const summary = ${wrapTemplate(`Implemented ${escaped}TypeBuilder${escaped} updates.`)};`,
+        "await taskComplete(summary)",
+      ].join("\n"),
+    )
+  })
+
+  it("escapes internal backticks in writeFile content assigned to variables", () => {
+    const input = [
+      "const body = `const value = `next``;",
+      "await writeFile({",
+      '  path: "src/example.ts",',
+      "  content: body,",
+      "})",
+    ].join("\n")
+
+    const output = preprocessScript(input)
+
+    assert.strictEqual(
+      output.includes(
+        `const body = ${wrapTemplate(`const value = ${escaped}next${escaped}`)};`,
+      ),
+      true,
+    )
   })
 
   it("fixes broken patch", () => {

--- a/src/ScriptPreprocessing.test.ts
+++ b/src/ScriptPreprocessing.test.ts
@@ -1,0 +1,77 @@
+import { assert, describe, it } from "@effect/vitest"
+import { preprocessScript } from "./ScriptPreprocessing.ts"
+
+const tick = "`"
+const escaped = "\\`"
+const wrapTemplate = (value: string): string => `${tick}${value}${tick}`
+
+describe("preprocessScript", () => {
+  it("escapes internal backticks in applyPatch templates", () => {
+    const input = [
+      "await applyPatch(`",
+      "*** Begin Patch",
+      "*** Update File: src/example.ts",
+      "@@",
+      "-const oldValue = `old`",
+      "+const newValue = `new`",
+      "*** End Patch",
+      "`)",
+    ].join("\n")
+
+    const output = preprocessScript(input)
+
+    assert.strictEqual(
+      output.includes(`-const oldValue = ${escaped}old${escaped}`),
+      true,
+    )
+    assert.strictEqual(
+      output.includes(`+const newValue = ${escaped}new${escaped}`),
+      true,
+    )
+  })
+
+  it("escapes internal backticks in writeFile content templates", () => {
+    const input = [
+      "await writeFile({",
+      '  path: "src/example.ts",',
+      "  content: `const value = `next``,",
+      "})",
+    ].join("\n")
+
+    const output = preprocessScript(input)
+
+    assert.strictEqual(
+      output.includes(
+        `content: ${wrapTemplate(`const value = ${escaped}next${escaped}`)},`,
+      ),
+      true,
+    )
+  })
+
+  it("escapes internal backticks in taskComplete templates", () => {
+    const input = "await taskComplete(`Implemented `TypeBuilder` updates.`)"
+
+    const output = preprocessScript(input)
+
+    assert.strictEqual(
+      output,
+      `await taskComplete(${wrapTemplate(`Implemented ${escaped}TypeBuilder${escaped} updates.`)})`,
+    )
+  })
+
+  it("does not change scripts when target templates are already escaped", () => {
+    const input = [
+      `await applyPatch(${wrapTemplate(`const value = ${escaped}safe${escaped}`)})`,
+      `await writeFile({ path: "src/example.ts", content: ${wrapTemplate(`already ${escaped}safe${escaped}`)} })`,
+      `await taskComplete(${wrapTemplate(`All done with ${escaped}safe${escaped} backticks.`)})`,
+    ].join("\n")
+
+    assert.strictEqual(preprocessScript(input), input)
+  })
+
+  it("does not modify non-target function calls", () => {
+    const input = "await otherTool(`Keep `this` untouched.`)"
+
+    assert.strictEqual(preprocessScript(input), input)
+  })
+})

--- a/src/ScriptPreprocessing.test.ts
+++ b/src/ScriptPreprocessing.test.ts
@@ -157,15 +157,15 @@ describe("preprocessScript", () => {
     )
   })
 
-  it("fixes broken patch", () => {
+  it.each(["patch", "patch2"])("fixes broken %s", (fixture) => {
     const content = readFileSync(
-      join(__dirname, "fixtures", "patch-broken.txt"),
+      join(__dirname, "fixtures", `${fixture}-broken.txt`),
       "utf-8",
     )
     const fixed = readFileSync(
-      join(__dirname, "fixtures", "patch-fixed.txt"),
+      join(__dirname, "fixtures", `${fixture}-fixed.txt`),
       "utf-8",
     )
-    assert.strictEqual(preprocessScript(content).trim(), fixed.trim())
+    assert.equal(preprocessScript(content), fixed)
   })
 })

--- a/src/ScriptPreprocessing.test.ts
+++ b/src/ScriptPreprocessing.test.ts
@@ -1,5 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
 import { preprocessScript } from "./ScriptPreprocessing.ts"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 
 const tick = "`"
 const escaped = "\\`"
@@ -73,5 +75,17 @@ describe("preprocessScript", () => {
     const input = "await otherTool(`Keep `this` untouched.`)"
 
     assert.strictEqual(preprocessScript(input), input)
+  })
+
+  it("fixes broken patch", () => {
+    const content = readFileSync(
+      join(__dirname, "fixtures", "patch-broken.txt"),
+      "utf-8",
+    )
+    const fixed = readFileSync(
+      join(__dirname, "fixtures", "patch-fixed.txt"),
+      "utf-8",
+    )
+    assert.strictEqual(preprocessScript(content).trim(), fixed.trim())
   })
 })

--- a/src/ScriptPreprocessing.ts
+++ b/src/ScriptPreprocessing.ts
@@ -1,0 +1,183 @@
+const isIdentifierChar = (char: string | undefined): boolean =>
+  char !== undefined && /[A-Za-z0-9_$]/.test(char)
+
+const hasIdentifierBoundary = (
+  text: string,
+  index: number,
+  length: number,
+): boolean =>
+  !isIdentifierChar(text[index - 1]) && !isIdentifierChar(text[index + length])
+
+const findNextIdentifier = (
+  text: string,
+  identifier: string,
+  from: number,
+): number => {
+  let index = text.indexOf(identifier, from)
+  while (index !== -1) {
+    if (hasIdentifierBoundary(text, index, identifier.length)) {
+      return index
+    }
+    index = text.indexOf(identifier, index + identifier.length)
+  }
+  return -1
+}
+
+const skipWhitespace = (text: string, start: number): number => {
+  let i = start
+  while (i < text.length && /\s/.test(text[i]!)) {
+    i++
+  }
+  return i
+}
+
+const isEscaped = (text: string, index: number): boolean => {
+  let slashCount = 0
+  let i = index - 1
+  while (i >= 0 && text[i] === "\\") {
+    slashCount++
+    i--
+  }
+  return slashCount % 2 === 1
+}
+
+const escapeUnescapedBackticks = (text: string): string => {
+  let out = ""
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!
+    if (char === "`" && !isEscaped(text, i)) {
+      out += "\\`"
+      continue
+    }
+    out += char
+  }
+  return out
+}
+
+const findTemplateEnd = (
+  text: string,
+  start: number,
+  isTerminator: (char: string | undefined) => boolean,
+): number => {
+  for (let i = start + 1; i < text.length; i++) {
+    if (text[i] !== "`" || isEscaped(text, i)) {
+      continue
+    }
+    const next = skipWhitespace(text, i + 1)
+    if (isTerminator(text[next])) {
+      return i
+    }
+  }
+  return -1
+}
+
+const fixCallTemplateArgument = (
+  script: string,
+  functionName: string,
+  isTerminator: (char: string | undefined) => boolean,
+): string => {
+  let out = script
+  let cursor = 0
+
+  while (cursor < out.length) {
+    const callStart = findNextIdentifier(out, functionName, cursor)
+    if (callStart === -1) {
+      break
+    }
+
+    const openParen = skipWhitespace(out, callStart + functionName.length)
+    if (out[openParen] !== "(") {
+      cursor = callStart + functionName.length
+      continue
+    }
+
+    const templateStart = skipWhitespace(out, openParen + 1)
+    if (out[templateStart] !== "`") {
+      cursor = openParen + 1
+      continue
+    }
+
+    const templateEnd = findTemplateEnd(out, templateStart, isTerminator)
+    if (templateEnd === -1) {
+      cursor = templateStart + 1
+      continue
+    }
+
+    const original = out.slice(templateStart + 1, templateEnd)
+    const escaped = escapeUnescapedBackticks(original)
+    if (escaped !== original) {
+      out = `${out.slice(0, templateStart + 1)}${escaped}${out.slice(templateEnd)}`
+      cursor = templateEnd + (escaped.length - original.length) + 1
+      continue
+    }
+
+    cursor = templateEnd + 1
+  }
+
+  return out
+}
+
+const fixWriteFileContentTemplates = (script: string): string => {
+  let out = script
+  let cursor = 0
+
+  while (cursor < out.length) {
+    const callStart = findNextIdentifier(out, "writeFile", cursor)
+    if (callStart === -1) {
+      break
+    }
+
+    const openParen = skipWhitespace(out, callStart + "writeFile".length)
+    if (out[openParen] !== "(") {
+      cursor = callStart + "writeFile".length
+      continue
+    }
+
+    const contentKey = findNextIdentifier(out, "content", openParen + 1)
+    if (contentKey === -1) {
+      cursor = openParen + 1
+      continue
+    }
+
+    const colon = skipWhitespace(out, contentKey + "content".length)
+    if (out[colon] !== ":") {
+      cursor = contentKey + "content".length
+      continue
+    }
+
+    const templateStart = skipWhitespace(out, colon + 1)
+    if (out[templateStart] !== "`") {
+      cursor = templateStart + 1
+      continue
+    }
+
+    const templateEnd = findTemplateEnd(
+      out,
+      templateStart,
+      (char) => char === "}" || char === ",",
+    )
+    if (templateEnd === -1) {
+      cursor = templateStart + 1
+      continue
+    }
+
+    const original = out.slice(templateStart + 1, templateEnd)
+    const escaped = escapeUnescapedBackticks(original)
+    if (escaped !== original) {
+      out = `${out.slice(0, templateStart + 1)}${escaped}${out.slice(templateEnd)}`
+      cursor = templateEnd + (escaped.length - original.length) + 1
+      continue
+    }
+
+    cursor = templateEnd + 1
+  }
+
+  return out
+}
+
+export const preprocessScript = (script: string): string =>
+  ["applyPatch", "taskComplete"].reduce(
+    (current, functionName) =>
+      fixCallTemplateArgument(current, functionName, (char) => char === ")"),
+    fixWriteFileContentTemplates(script),
+  )

--- a/src/ScriptPreprocessing.ts
+++ b/src/ScriptPreprocessing.ts
@@ -1,6 +1,9 @@
 const isIdentifierChar = (char: string | undefined): boolean =>
   char !== undefined && /[A-Za-z0-9_$]/.test(char)
 
+const isIdentifierStartChar = (char: string | undefined): boolean =>
+  char !== undefined && /[A-Za-z_$]/.test(char)
+
 const hasIdentifierBoundary = (
   text: string,
   index: number,
@@ -31,6 +34,23 @@ const skipWhitespace = (text: string, start: number): number => {
   return i
 }
 
+const parseIdentifier = (
+  text: string,
+  start: number,
+): { readonly name: string; readonly end: number } | undefined => {
+  if (!isIdentifierStartChar(text[start])) {
+    return undefined
+  }
+  let end = start + 1
+  while (end < text.length && isIdentifierChar(text[end])) {
+    end++
+  }
+  return {
+    name: text.slice(start, end),
+    end,
+  }
+}
+
 const isEscaped = (text: string, index: number): boolean => {
   let slashCount = 0
   let i = index - 1
@@ -41,12 +61,37 @@ const isEscaped = (text: string, index: number): boolean => {
   return slashCount % 2 === 1
 }
 
-const escapeUnescapedBackticks = (text: string): string => {
-  let out = ""
+const needsTemplateEscaping = (text: string): boolean => {
   for (let i = 0; i < text.length; i++) {
     const char = text[i]!
     if (char === "`" && !isEscaped(text, i)) {
+      return true
+    }
+    if (char === "$" && text[i + 1] === "{" && !isEscaped(text, i)) {
+      return true
+    }
+  }
+  return false
+}
+
+const escapeTemplateLiteralContent = (text: string): string => {
+  if (!needsTemplateEscaping(text)) {
+    return text
+  }
+
+  let out = ""
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!
+    if (char === "\\") {
+      out += "\\\\"
+      continue
+    }
+    if (char === "`" && !isEscaped(text, i)) {
       out += "\\`"
+      continue
+    }
+    if (char === "$" && text[i + 1] === "{" && !isEscaped(text, i)) {
+      out += "\\$"
       continue
     }
     out += char
@@ -67,6 +112,21 @@ const findTemplateEnd = (
     if (isTerminator(text[next])) {
       return i
     }
+  }
+  return -1
+}
+
+const findTypeAnnotationAssignment = (text: string, start: number): number => {
+  let i = start
+  while (i < text.length) {
+    const char = text[i]!
+    if (char === "=") {
+      return i
+    }
+    if (char === "\n" || char === ";") {
+      return -1
+    }
+    i++
   }
   return -1
 }
@@ -104,7 +164,7 @@ const fixCallTemplateArgument = (
     }
 
     const original = out.slice(templateStart + 1, templateEnd)
-    const escaped = escapeUnescapedBackticks(original)
+    const escaped = escapeTemplateLiteralContent(original)
     if (escaped !== original) {
       out = `${out.slice(0, templateStart + 1)}${escaped}${out.slice(templateEnd)}`
       cursor = templateEnd + (escaped.length - original.length) + 1
@@ -112,6 +172,43 @@ const fixCallTemplateArgument = (
     }
 
     cursor = templateEnd + 1
+  }
+
+  return out
+}
+
+const collectCallArgumentIdentifiers = (
+  script: string,
+  functionName: string,
+): ReadonlySet<string> => {
+  const out = new Set<string>()
+  let cursor = 0
+
+  while (cursor < script.length) {
+    const callStart = findNextIdentifier(script, functionName, cursor)
+    if (callStart === -1) {
+      break
+    }
+
+    const openParen = skipWhitespace(script, callStart + functionName.length)
+    if (script[openParen] !== "(") {
+      cursor = callStart + functionName.length
+      continue
+    }
+
+    const argumentStart = skipWhitespace(script, openParen + 1)
+    const identifier = parseIdentifier(script, argumentStart)
+    if (identifier === undefined) {
+      cursor = openParen + 1
+      continue
+    }
+
+    const argumentEnd = skipWhitespace(script, identifier.end)
+    if (script[argumentEnd] === ")" || script[argumentEnd] === ",") {
+      out.add(identifier.name)
+    }
+
+    cursor = identifier.end
   }
 
   return out
@@ -162,7 +259,7 @@ const fixWriteFileContentTemplates = (script: string): string => {
     }
 
     const original = out.slice(templateStart + 1, templateEnd)
-    const escaped = escapeUnescapedBackticks(original)
+    const escaped = escapeTemplateLiteralContent(original)
     if (escaped !== original) {
       out = `${out.slice(0, templateStart + 1)}${escaped}${out.slice(templateEnd)}`
       cursor = templateEnd + (escaped.length - original.length) + 1
@@ -175,9 +272,149 @@ const fixWriteFileContentTemplates = (script: string): string => {
   return out
 }
 
+const collectWriteFileContentIdentifiers = (
+  script: string,
+): ReadonlySet<string> => {
+  const out = new Set<string>()
+  let cursor = 0
+
+  while (cursor < script.length) {
+    const callStart = findNextIdentifier(script, "writeFile", cursor)
+    if (callStart === -1) {
+      break
+    }
+
+    const openParen = skipWhitespace(script, callStart + "writeFile".length)
+    if (script[openParen] !== "(") {
+      cursor = callStart + "writeFile".length
+      continue
+    }
+
+    const contentKey = findNextIdentifier(script, "content", openParen + 1)
+    if (contentKey === -1) {
+      cursor = openParen + 1
+      continue
+    }
+
+    const afterContent = skipWhitespace(script, contentKey + "content".length)
+    if (script[afterContent] === ":") {
+      const valueStart = skipWhitespace(script, afterContent + 1)
+      const identifier = parseIdentifier(script, valueStart)
+      if (identifier !== undefined) {
+        const valueEnd = skipWhitespace(script, identifier.end)
+        if (script[valueEnd] === "}" || script[valueEnd] === ",") {
+          out.add(identifier.name)
+        }
+      }
+      cursor = valueStart + 1
+      continue
+    }
+
+    if (script[afterContent] === "}" || script[afterContent] === ",") {
+      out.add("content")
+      cursor = afterContent + 1
+      continue
+    }
+
+    cursor = afterContent + 1
+  }
+
+  return out
+}
+
+const fixAssignedTemplate = (script: string, variableName: string): string => {
+  let out = script
+  let cursor = 0
+
+  while (cursor < out.length) {
+    const variableStart = findNextIdentifier(out, variableName, cursor)
+    if (variableStart === -1) {
+      break
+    }
+
+    let assignmentStart = skipWhitespace(
+      out,
+      variableStart + variableName.length,
+    )
+    if (out[assignmentStart] === ":") {
+      assignmentStart = findTypeAnnotationAssignment(out, assignmentStart + 1)
+      if (assignmentStart === -1) {
+        cursor = variableStart + variableName.length
+        continue
+      }
+    }
+
+    if (
+      out[assignmentStart] !== "=" ||
+      out[assignmentStart + 1] === "=" ||
+      out[assignmentStart + 1] === ">"
+    ) {
+      cursor = variableStart + variableName.length
+      continue
+    }
+
+    const templateStart = skipWhitespace(out, assignmentStart + 1)
+    if (out[templateStart] !== "`") {
+      cursor = templateStart + 1
+      continue
+    }
+
+    const templateEnd = findTemplateEnd(
+      out,
+      templateStart,
+      (char) =>
+        char === undefined ||
+        char === ";" ||
+        char === "," ||
+        char === ")" ||
+        char === "}" ||
+        char === "]",
+    )
+    if (templateEnd === -1) {
+      cursor = templateStart + 1
+      continue
+    }
+
+    const original = out.slice(templateStart + 1, templateEnd)
+    const escaped = escapeTemplateLiteralContent(original)
+    if (escaped !== original) {
+      out = `${out.slice(0, templateStart + 1)}${escaped}${out.slice(templateEnd)}`
+      cursor = templateEnd + (escaped.length - original.length) + 1
+      continue
+    }
+
+    cursor = templateEnd + 1
+  }
+
+  return out
+}
+
+const fixAssignedTemplatesForToolCalls = (script: string): string => {
+  const identifiers = new Set<string>()
+  for (const functionName of ["applyPatch", "taskComplete"] as const) {
+    for (const identifier of collectCallArgumentIdentifiers(
+      script,
+      functionName,
+    )) {
+      identifiers.add(identifier)
+    }
+  }
+  for (const identifier of collectWriteFileContentIdentifiers(script)) {
+    identifiers.add(identifier)
+  }
+
+  let out = script
+  for (const identifier of identifiers) {
+    out = fixAssignedTemplate(out, identifier)
+  }
+  return out
+}
+
 export const preprocessScript = (script: string): string =>
-  ["applyPatch", "taskComplete"].reduce(
-    (current, functionName) =>
-      fixCallTemplateArgument(current, functionName, (char) => char === ")"),
-    fixWriteFileContentTemplates(script),
+  fixAssignedTemplatesForToolCalls(
+    ["applyPatch", "taskComplete"].reduce(
+      (current, functionName) =>
+        fixCallTemplateArgument(current, functionName, (char) => char === ")"),
+      fixWriteFileContentTemplates(script),
+    ),
   )

--- a/src/fixtures/patch-broken.txt
+++ b/src/fixtures/patch-broken.txt
@@ -1,0 +1,187 @@
+const patch = `*** Begin Patch
+*** Add File: src/ScriptPreprocessing.ts
++const isIdentifierChar = (char: string | undefined): boolean =>
++  char !== undefined && /[A-Za-z0-9_$]/.test(char)
++
++const hasIdentifierBoundary = (
++  text: string,
++  index: number,
++  length: number,
++): boolean =>
++  !isIdentifierChar(text[index - 1]) && !isIdentifierChar(text[index + length])
++
++const findNextIdentifier = (
++  text: string,
++  identifier: string,
++  from: number,
++): number => {
++  let index = text.indexOf(identifier, from)
++  while (index !== -1) {
++    if (hasIdentifierBoundary(text, index, identifier.length)) {
++      return index
++    }
++    index = text.indexOf(identifier, index + identifier.length)
++  }
++  return -1
++}
++
++const skipWhitespace = (text: string, start: number): number => {
++  let i = start
++  while (i < text.length && /\s/.test(text[i]!)) {
++    i++
++  }
++  return i
++}
++
++const isEscaped = (text: string, index: number): boolean => {
++  let slashCount = 0
++  let i = index - 1
++  while (i >= 0 && text[i] === "\\") {
++    slashCount++
++    i--
++  }
++  return slashCount % 2 === 1
++}
++
++const escapeUnescapedBackticks = (text: string): string => {
++  let out = ""
++  for (let i = 0; i < text.length; i++) {
++    const char = text[i]!
++    if (char === "`" && !isEscaped(text, i)) {
++      out += "\\`"
++      continue
++    }
++    out += char
++  }
++  return out
++}
++
++const findTemplateEnd = (
++  text: string,
++  start: number,
++  isTerminator: (char: string | undefined) => boolean,
++): number => {
++  for (let i = start + 1; i < text.length; i++) {
++    if (text[i] !== "`" || isEscaped(text, i)) {
++      continue
++    }
++    const next = skipWhitespace(text, i + 1)
++    if (isTerminator(text[next])) {
++      return i
++    }
++  }
++  return -1
++}
++
++const fixCallTemplateArgument = (
++  script: string,
++  functionName: string,
++  isTerminator: (char: string | undefined) => boolean,
++): string => {
++  let out = script
++  let cursor = 0
++
++  while (cursor < out.length) {
++    const callStart = findNextIdentifier(out, functionName, cursor)
++    if (callStart === -1) {
++      break
++    }
++
++    const openParen = skipWhitespace(out, callStart + functionName.length)
++    if (out[openParen] !== "(") {
++      cursor = callStart + functionName.length
++      continue
++    }
++
++    const templateStart = skipWhitespace(out, openParen + 1)
++    if (out[templateStart] !== "`") {
++      cursor = openParen + 1
++      continue
++    }
++
++    const templateEnd = findTemplateEnd(out, templateStart, isTerminator)
++    if (templateEnd === -1) {
++      cursor = templateStart + 1
++      continue
++    }
++
++    const original = out.slice(templateStart + 1, templateEnd)
++    const escaped = escapeUnescapedBackticks(original)
++    if (escaped !== original) {
++      out = `${out.slice(0, templateStart + 1)}${escaped}${out.slice(templateEnd)}`
++      cursor = templateEnd + (escaped.length - original.length) + 1
++      continue
++    }
++
++    cursor = templateEnd + 1
++  }
++
++  return out
++}
++
++const fixWriteFileContentTemplates = (script: string): string => {
++  let out = script
++  let cursor = 0
++
++  while (cursor < out.length) {
++    const callStart = findNextIdentifier(out, "writeFile", cursor)
++    if (callStart === -1) {
++      break
++    }
++
++    const openParen = skipWhitespace(out, callStart + "writeFile".length)
++    if (out[openParen] !== "(") {
++      cursor = callStart + "writeFile".length
++      continue
++    }
++
++    const contentKey = findNextIdentifier(out, "content", openParen + 1)
++    if (contentKey === -1) {
++      cursor = openParen + 1
++      continue
++    }
++
++    const colon = skipWhitespace(out, contentKey + "content".length)
++    if (out[colon] !== ":") {
++      cursor = contentKey + "content".length
++      continue
++    }
++
++    const templateStart = skipWhitespace(out, colon + 1)
++    if (out[templateStart] !== "`") {
++      cursor = templateStart + 1
++      continue
++    }
++
++    const templateEnd = findTemplateEnd(
++      out,
++      templateStart,
++      (char) => char === "}" || char === ",",
++    )
++    if (templateEnd === -1) {
++      cursor = templateStart + 1
++      continue
++    }
++
++    const original = out.slice(templateStart + 1, templateEnd)
++    const escaped = escapeUnescapedBackticks(original)
++    if (escaped !== original) {
++      out = `${out.slice(0, templateStart + 1)}${escaped}${out.slice(templateEnd)}`
++      cursor = templateEnd + (escaped.length - original.length) + 1
++      continue
++    }
++
++    cursor = templateEnd + 1
++  }
++
++  return out
++}
++
++export const preprocessScript = (script: string): string =>
++  ["applyPatch", "taskComplete"].reduce(
++    (current, functionName) =>
++      fixCallTemplateArgument(current, functionName, (char) => char === ")"),
++    fixWriteFileContentTemplates(script),
++  )
+*** End Patch`;
+console.log(await applyPatch(patch));

--- a/src/fixtures/patch-fixed.txt
+++ b/src/fixtures/patch-fixed.txt
@@ -1,0 +1,187 @@
+const patch = `*** Begin Patch
+*** Add File: src/ScriptPreprocessing.ts
++const isIdentifierChar = (char: string | undefined): boolean =>
++  char !== undefined && /[A-Za-z0-9_$]/.test(char)
++
++const hasIdentifierBoundary = (
++  text: string,
++  index: number,
++  length: number,
++): boolean =>
++  !isIdentifierChar(text[index - 1]) && !isIdentifierChar(text[index + length])
++
++const findNextIdentifier = (
++  text: string,
++  identifier: string,
++  from: number,
++): number => {
++  let index = text.indexOf(identifier, from)
++  while (index !== -1) {
++    if (hasIdentifierBoundary(text, index, identifier.length)) {
++      return index
++    }
++    index = text.indexOf(identifier, index + identifier.length)
++  }
++  return -1
++}
++
++const skipWhitespace = (text: string, start: number): number => {
++  let i = start
++  while (i < text.length && /\\s/.test(text[i]!)) {
++    i++
++  }
++  return i
++}
++
++const isEscaped = (text: string, index: number): boolean => {
++  let slashCount = 0
++  let i = index - 1
++  while (i >= 0 && text[i] === "\\\\") {
++    slashCount++
++    i--
++  }
++  return slashCount % 2 === 1
++}
++
++const escapeUnescapedBackticks = (text: string): string => {
++  let out = ""
++  for (let i = 0; i < text.length; i++) {
++    const char = text[i]!
++    if (char === "\`" && !isEscaped(text, i)) {
++      out += "\\\\\`"
++      continue
++    }
++    out += char
++  }
++  return out
++}
++
++const findTemplateEnd = (
++  text: string,
++  start: number,
++  isTerminator: (char: string | undefined) => boolean,
++): number => {
++  for (let i = start + 1; i < text.length; i++) {
++    if (text[i] !== "\`" || isEscaped(text, i)) {
++      continue
++    }
++    const next = skipWhitespace(text, i + 1)
++    if (isTerminator(text[next])) {
++      return i
++    }
++  }
++  return -1
++}
++
++const fixCallTemplateArgument = (
++  script: string,
++  functionName: string,
++  isTerminator: (char: string | undefined) => boolean,
++): string => {
++  let out = script
++  let cursor = 0
++
++  while (cursor < out.length) {
++    const callStart = findNextIdentifier(out, functionName, cursor)
++    if (callStart === -1) {
++      break
++    }
++
++    const openParen = skipWhitespace(out, callStart + functionName.length)
++    if (out[openParen] !== "(") {
++      cursor = callStart + functionName.length
++      continue
++    }
++
++    const templateStart = skipWhitespace(out, openParen + 1)
++    if (out[templateStart] !== "\`") {
++      cursor = openParen + 1
++      continue
++    }
++
++    const templateEnd = findTemplateEnd(out, templateStart, isTerminator)
++    if (templateEnd === -1) {
++      cursor = templateStart + 1
++      continue
++    }
++
++    const original = out.slice(templateStart + 1, templateEnd)
++    const escaped = escapeUnescapedBackticks(original)
++    if (escaped !== original) {
++      out = \`\${out.slice(0, templateStart + 1)}\${escaped}\${out.slice(templateEnd)}\`
++      cursor = templateEnd + (escaped.length - original.length) + 1
++      continue
++    }
++
++    cursor = templateEnd + 1
++  }
++
++  return out
++}
++
++const fixWriteFileContentTemplates = (script: string): string => {
++  let out = script
++  let cursor = 0
++
++  while (cursor < out.length) {
++    const callStart = findNextIdentifier(out, "writeFile", cursor)
++    if (callStart === -1) {
++      break
++    }
++
++    const openParen = skipWhitespace(out, callStart + "writeFile".length)
++    if (out[openParen] !== "(") {
++      cursor = callStart + "writeFile".length
++      continue
++    }
++
++    const contentKey = findNextIdentifier(out, "content", openParen + 1)
++    if (contentKey === -1) {
++      cursor = openParen + 1
++      continue
++    }
++
++    const colon = skipWhitespace(out, contentKey + "content".length)
++    if (out[colon] !== ":") {
++      cursor = contentKey + "content".length
++      continue
++    }
++
++    const templateStart = skipWhitespace(out, colon + 1)
++    if (out[templateStart] !== "\`") {
++      cursor = templateStart + 1
++      continue
++    }
++
++    const templateEnd = findTemplateEnd(
++      out,
++      templateStart,
++      (char) => char === "}" || char === ",",
++    )
++    if (templateEnd === -1) {
++      cursor = templateStart + 1
++      continue
++    }
++
++    const original = out.slice(templateStart + 1, templateEnd)
++    const escaped = escapeUnescapedBackticks(original)
++    if (escaped !== original) {
++      out = \`\${out.slice(0, templateStart + 1)}\${escaped}\${out.slice(templateEnd)}\`
++      cursor = templateEnd + (escaped.length - original.length) + 1
++      continue
++    }
++
++    cursor = templateEnd + 1
++  }
++
++  return out
++}
++
++export const preprocessScript = (script: string): string =>
++  ["applyPatch", "taskComplete"].reduce(
++    (current, functionName) =>
++      fixCallTemplateArgument(current, functionName, (char) => char === ")"),
++    fixWriteFileContentTemplates(script),
++  )
+*** End Patch`;
+console.log(await applyPatch(patch));

--- a/src/fixtures/patch2-broken.txt
+++ b/src/fixtures/patch2-broken.txt
@@ -1,0 +1,257 @@
+const patch = `*** Begin Patch
+*** Update File: src/ScriptPreprocessing.ts
+@@
+ const isIdentifierChar = (char: string | undefined): boolean =>
+   char !== undefined && /[A-Za-z0-9_$]/.test(char)
++
++const isIdentifierStartChar = (char: string | undefined): boolean =>
++  char !== undefined && /[A-Za-z_$]/.test(char)
+@@
+ const skipWhitespace = (text: string, start: number): number => {
+   let i = start
+   while (i < text.length && /\\s/.test(text[i]!)) {
+     i++
+   }
+   return i
+ }
++
++const hasNewline = (text: string): boolean => text.includes("\\n")
++
++const parseIdentifier = (
++  text: string,
++  start: number,
++): { readonly name: string; readonly end: number } | undefined => {
++  if (!isIdentifierStartChar(text[start])) {
++    return undefined
++  }
++  let end = start + 1
++  while (end < text.length && isIdentifierChar(text[end])) {
++    end++
++  }
++  return {
++    name: text.slice(start, end),
++    end,
++  }
++}
+@@
+ const findTemplateEnd = (
+   text: string,
+   start: number,
+   isTerminator: (char: string | undefined) => boolean,
+@@
+   return -1
+ }
++
++const findTypeAnnotationAssignment = (text: string, start: number): number => {
++  let i = start
++  while (i < text.length) {
++    const char = text[i]!
++    if (char === "=") {
++      return i
++    }
++    if (char === "\\n" || char === ";") {
++      return -1
++    }
++    i++
++  }
++  return -1
++}
+@@
+ const fixCallTemplateArgument = (
+   script: string,
+   functionName: string,
+   isTerminator: (char: string | undefined) => boolean,
+@@
+   return out
+ }
++
++const collectCallArgumentIdentifiers = (
++  script: string,
++  functionName: string,
++): ReadonlySet<string> => {
++  const out = new Set<string>()
++  let cursor = 0
++
++  while (cursor < script.length) {
++    const callStart = findNextIdentifier(script, functionName, cursor)
++    if (callStart === -1) {
++      break
++    }
++
++    const openParen = skipWhitespace(script, callStart + functionName.length)
++    if (script[openParen] !== "(") {
++      cursor = callStart + functionName.length
++      continue
++    }
++
++    const argumentStart = skipWhitespace(script, openParen + 1)
++    const identifier = parseIdentifier(script, argumentStart)
++    if (identifier === undefined) {
++      cursor = openParen + 1
++      continue
++    }
++
++    const argumentEnd = skipWhitespace(script, identifier.end)
++    if (script[argumentEnd] === ")" || script[argumentEnd] === ",") {
++      out.add(identifier.name)
++    }
++
++    cursor = identifier.end
++  }
++
++  return out
++}
+@@
+ const fixWriteFileContentTemplates = (script: string): string => {
+@@
+   return out
+ }
++
++const collectWriteFileContentIdentifiers = (
++  script: string,
++): ReadonlySet<string> => {
++  const out = new Set<string>()
++  let cursor = 0
++
++  while (cursor < script.length) {
++    const callStart = findNextIdentifier(script, "writeFile", cursor)
++    if (callStart === -1) {
++      break
++    }
++
++    const openParen = skipWhitespace(script, callStart + "writeFile".length)
++    if (script[openParen] !== "(") {
++      cursor = callStart + "writeFile".length
++      continue
++    }
++
++    const contentKey = findNextIdentifier(script, "content", openParen + 1)
++    if (contentKey === -1) {
++      cursor = openParen + 1
++      continue
++    }
++
++    const afterContent = skipWhitespace(script, contentKey + "content".length)
++    if (script[afterContent] === ":") {
++      const valueStart = skipWhitespace(script, afterContent + 1)
++      const identifier = parseIdentifier(script, valueStart)
++      if (identifier !== undefined) {
++        const valueEnd = skipWhitespace(script, identifier.end)
++        if (script[valueEnd] === "}" || script[valueEnd] === ",") {
++          out.add(identifier.name)
++        }
++      }
++      cursor = valueStart + 1
++      continue
++    }
++
++    if (script[afterContent] === "}" || script[afterContent] === ",") {
++      out.add("content")
++      cursor = afterContent + 1
++      continue
++    }
++
++    cursor = afterContent + 1
++  }
++
++  return out
++}
++
++const fixAssignedTemplate = (script: string, variableName: string): string => {
++  let out = script
++  let cursor = 0
++
++  while (cursor < out.length) {
++    const variableStart = findNextIdentifier(out, variableName, cursor)
++    if (variableStart === -1) {
++      break
++    }
++
++    let assignmentStart = skipWhitespace(out, variableStart + variableName.length)
++    if (out[assignmentStart] === ":") {
++      assignmentStart = findTypeAnnotationAssignment(out, assignmentStart + 1)
++      if (assignmentStart === -1) {
++        cursor = variableStart + variableName.length
++        continue
++      }
++    }
++
++    if (
++      out[assignmentStart] !== "=" ||
++      out[assignmentStart + 1] === "=" ||
++      out[assignmentStart + 1] === ">"
++    ) {
++      cursor = variableStart + variableName.length
++      continue
++    }
++
++    const templateStart = skipWhitespace(out, assignmentStart + 1)
++    if (out[templateStart] !== "`") {
++      cursor = templateStart + 1
++      continue
++    }
++
++    const templateEnd = findTemplateEnd(
++      out,
++      templateStart,
++      (char) =>
++        char === undefined ||
++        char === ";" ||
++        char === "," ||
++        char === ")" ||
++        char === "}" ||
++        char === "]",
++    )
++    if (templateEnd === -1) {
++      cursor = templateStart + 1
++      continue
++    }
++
++    const original = out.slice(templateStart + 1, templateEnd)
++    const escaped = escapeUnescapedBackticks(original)
++    if (escaped !== original) {
++      out = `${out.slice(0, templateStart + 1)}${escaped}${out.slice(templateEnd)}`
++      cursor = templateEnd + (escaped.length - original.length) + 1
++      continue
++    }
++
++    cursor = templateEnd + 1
++  }
++
++  return out
++}
++
++const fixAssignedTemplatesForToolCalls = (script: string): string => {
++  const identifiers = new Set<string>()
++  for (const name of ["applyPatch", "taskComplete"] as const) {
++    for (const identifier of collectCallArgumentIdentifiers(script, name)) {
++      identifiers.add(identifier)
++    }
++  }
++  for (const identifier of collectWriteFileContentIdentifiers(script)) {
++    identifiers.add(identifier)
++  }
++
++  let out = script
++  for (const identifier of identifiers) {
++    out = fixAssignedTemplate(out, identifier)
++  }
++
++  return out
++}
+
+ export const preprocessScript = (script: string): string =>
+-  ["applyPatch", "taskComplete"].reduce(
+-    (current, functionName) =>
+-      fixCallTemplateArgument(current, functionName, (char) => char === ")"),
+-    fixWriteFileContentTemplates(script),
+-  )
++  fixAssignedTemplatesForToolCalls(
++    ["applyPatch", "taskComplete"].reduce(
++      (current, functionName) =>
++        fixCallTemplateArgument(current, functionName, (char) => char === ")"),
++      fixWriteFileContentTemplates(script),
++    ),
++  )
+*** End Patch`;
+console.log(await applyPatch(patch));

--- a/src/fixtures/patch2-fixed.txt
+++ b/src/fixtures/patch2-fixed.txt
@@ -1,0 +1,257 @@
+const patch = `*** Begin Patch
+*** Update File: src/ScriptPreprocessing.ts
+@@
+ const isIdentifierChar = (char: string | undefined): boolean =>
+   char !== undefined && /[A-Za-z0-9_$]/.test(char)
++
++const isIdentifierStartChar = (char: string | undefined): boolean =>
++  char !== undefined && /[A-Za-z_$]/.test(char)
+@@
+ const skipWhitespace = (text: string, start: number): number => {
+   let i = start
+   while (i < text.length && /\\\\s/.test(text[i]!)) {
+     i++
+   }
+   return i
+ }
++
++const hasNewline = (text: string): boolean => text.includes("\\\\n")
++
++const parseIdentifier = (
++  text: string,
++  start: number,
++): { readonly name: string; readonly end: number } | undefined => {
++  if (!isIdentifierStartChar(text[start])) {
++    return undefined
++  }
++  let end = start + 1
++  while (end < text.length && isIdentifierChar(text[end])) {
++    end++
++  }
++  return {
++    name: text.slice(start, end),
++    end,
++  }
++}
+@@
+ const findTemplateEnd = (
+   text: string,
+   start: number,
+   isTerminator: (char: string | undefined) => boolean,
+@@
+   return -1
+ }
++
++const findTypeAnnotationAssignment = (text: string, start: number): number => {
++  let i = start
++  while (i < text.length) {
++    const char = text[i]!
++    if (char === "=") {
++      return i
++    }
++    if (char === "\\\\n" || char === ";") {
++      return -1
++    }
++    i++
++  }
++  return -1
++}
+@@
+ const fixCallTemplateArgument = (
+   script: string,
+   functionName: string,
+   isTerminator: (char: string | undefined) => boolean,
+@@
+   return out
+ }
++
++const collectCallArgumentIdentifiers = (
++  script: string,
++  functionName: string,
++): ReadonlySet<string> => {
++  const out = new Set<string>()
++  let cursor = 0
++
++  while (cursor < script.length) {
++    const callStart = findNextIdentifier(script, functionName, cursor)
++    if (callStart === -1) {
++      break
++    }
++
++    const openParen = skipWhitespace(script, callStart + functionName.length)
++    if (script[openParen] !== "(") {
++      cursor = callStart + functionName.length
++      continue
++    }
++
++    const argumentStart = skipWhitespace(script, openParen + 1)
++    const identifier = parseIdentifier(script, argumentStart)
++    if (identifier === undefined) {
++      cursor = openParen + 1
++      continue
++    }
++
++    const argumentEnd = skipWhitespace(script, identifier.end)
++    if (script[argumentEnd] === ")" || script[argumentEnd] === ",") {
++      out.add(identifier.name)
++    }
++
++    cursor = identifier.end
++  }
++
++  return out
++}
+@@
+ const fixWriteFileContentTemplates = (script: string): string => {
+@@
+   return out
+ }
++
++const collectWriteFileContentIdentifiers = (
++  script: string,
++): ReadonlySet<string> => {
++  const out = new Set<string>()
++  let cursor = 0
++
++  while (cursor < script.length) {
++    const callStart = findNextIdentifier(script, "writeFile", cursor)
++    if (callStart === -1) {
++      break
++    }
++
++    const openParen = skipWhitespace(script, callStart + "writeFile".length)
++    if (script[openParen] !== "(") {
++      cursor = callStart + "writeFile".length
++      continue
++    }
++
++    const contentKey = findNextIdentifier(script, "content", openParen + 1)
++    if (contentKey === -1) {
++      cursor = openParen + 1
++      continue
++    }
++
++    const afterContent = skipWhitespace(script, contentKey + "content".length)
++    if (script[afterContent] === ":") {
++      const valueStart = skipWhitespace(script, afterContent + 1)
++      const identifier = parseIdentifier(script, valueStart)
++      if (identifier !== undefined) {
++        const valueEnd = skipWhitespace(script, identifier.end)
++        if (script[valueEnd] === "}" || script[valueEnd] === ",") {
++          out.add(identifier.name)
++        }
++      }
++      cursor = valueStart + 1
++      continue
++    }
++
++    if (script[afterContent] === "}" || script[afterContent] === ",") {
++      out.add("content")
++      cursor = afterContent + 1
++      continue
++    }
++
++    cursor = afterContent + 1
++  }
++
++  return out
++}
++
++const fixAssignedTemplate = (script: string, variableName: string): string => {
++  let out = script
++  let cursor = 0
++
++  while (cursor < out.length) {
++    const variableStart = findNextIdentifier(out, variableName, cursor)
++    if (variableStart === -1) {
++      break
++    }
++
++    let assignmentStart = skipWhitespace(out, variableStart + variableName.length)
++    if (out[assignmentStart] === ":") {
++      assignmentStart = findTypeAnnotationAssignment(out, assignmentStart + 1)
++      if (assignmentStart === -1) {
++        cursor = variableStart + variableName.length
++        continue
++      }
++    }
++
++    if (
++      out[assignmentStart] !== "=" ||
++      out[assignmentStart + 1] === "=" ||
++      out[assignmentStart + 1] === ">"
++    ) {
++      cursor = variableStart + variableName.length
++      continue
++    }
++
++    const templateStart = skipWhitespace(out, assignmentStart + 1)
++    if (out[templateStart] !== "\`") {
++      cursor = templateStart + 1
++      continue
++    }
++
++    const templateEnd = findTemplateEnd(
++      out,
++      templateStart,
++      (char) =>
++        char === undefined ||
++        char === ";" ||
++        char === "," ||
++        char === ")" ||
++        char === "}" ||
++        char === "]",
++    )
++    if (templateEnd === -1) {
++      cursor = templateStart + 1
++      continue
++    }
++
++    const original = out.slice(templateStart + 1, templateEnd)
++    const escaped = escapeUnescapedBackticks(original)
++    if (escaped !== original) {
++      out = \`\${out.slice(0, templateStart + 1)}\${escaped}\${out.slice(templateEnd)}\`
++      cursor = templateEnd + (escaped.length - original.length) + 1
++      continue
++    }
++
++    cursor = templateEnd + 1
++  }
++
++  return out
++}
++
++const fixAssignedTemplatesForToolCalls = (script: string): string => {
++  const identifiers = new Set<string>()
++  for (const name of ["applyPatch", "taskComplete"] as const) {
++    for (const identifier of collectCallArgumentIdentifiers(script, name)) {
++      identifiers.add(identifier)
++    }
++  }
++  for (const identifier of collectWriteFileContentIdentifiers(script)) {
++    identifiers.add(identifier)
++  }
++
++  let out = script
++  for (const identifier of identifiers) {
++    out = fixAssignedTemplate(out, identifier)
++  }
++
++  return out
++}
+
+ export const preprocessScript = (script: string): string =>
+-  ["applyPatch", "taskComplete"].reduce(
+-    (current, functionName) =>
+-      fixCallTemplateArgument(current, functionName, (char) => char === ")"),
+-    fixWriteFileContentTemplates(script),
+-  )
++  fixAssignedTemplatesForToolCalls(
++    ["applyPatch", "taskComplete"].reduce(
++      (current, functionName) =>
++        fixCallTemplateArgument(current, functionName, (char) => char === ")"),
++      fixWriteFileContentTemplates(script),
++    ),
++  )
+*** End Patch`;
+console.log(await applyPatch(patch));


### PR DESCRIPTION
## Summary
- extend script pre-processing to also handle target templates assigned to variables before `applyPatch(...)`, `taskComplete(...)`, and `writeFile({ content: ... })` calls
- expand targeted escaping for broken tool templates to cover unescaped backticks, unescaped `${...}` interpolations, and backslashes when recovery is needed
- add regression coverage for interpolation escaping and variable-assignment patterns across all three target tools, while keeping non-target behavior unchanged

## Validation
- `pnpm check` ✅
- `pnpm test` ✅