### PR TITLE
TIM-744 Limit bash tool timeout to four minutes

### DIFF
--- a/.changeset/tasty-years-tie.md
+++ b/.changeset/tasty-years-tie.md
@@ -1,0 +1,5 @@
+---
+"clanka": patch
+---
+
+Cap the bash tool timeout at four minutes and document the maximum timeout in the tool schema.

--- a/src/AgentTools.test.ts
+++ b/src/AgentTools.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { normalizeBashTimeoutMs } from "./AgentTools.ts"
+
+describe("normalizeBashTimeoutMs", () => {
+  it("uses default timeout when timeoutMs is not provided", () => {
+    expect(normalizeBashTimeoutMs(undefined)).toBe(120_000)
+  })
+
+  it("preserves timeoutMs when it is below the maximum", () => {
+    expect(normalizeBashTimeoutMs(180_000)).toBe(180_000)
+  })
+
+  it("caps timeoutMs at four minutes", () => {
+    expect(normalizeBashTimeoutMs(600_000)).toBe(240_000)
+  })
+})

--- a/src/AgentTools.ts
+++ b/src/AgentTools.ts
@@ -22,6 +22,12 @@ import * as Data from "effect/Data"
 import * as Layer from "effect/Layer"
 import * as SemanticSearch from "./SemanticSearch.ts"
 
+const BASH_DEFAULT_TIMEOUT_MS = 120_000
+const BASH_MAX_TIMEOUT_MS = 240_000
+
+export const normalizeBashTimeoutMs = (timeoutMs: number | undefined): number =>
+  Math.min(timeoutMs ?? BASH_DEFAULT_TIMEOUT_MS, BASH_MAX_TIMEOUT_MS)
+
 /**
  * @since 1.0.0
  * @category Context
@@ -124,7 +130,7 @@ export const AgentTools = Toolkit.make(
     parameters: Schema.Struct({
       command: Schema.String,
       timeoutMs: Schema.optional(Schema.Finite).annotate({
-        documentation: "Timeout in ms (default: 120000)",
+        documentation: "Timeout in ms (default: 120000, max: 240000)",
       }),
     }).annotate({
       identifier: "command",
@@ -372,7 +378,7 @@ export const AgentToolHandlersNoDeps = AgentToolsWithSearch.toLayer(
         return yield* Effect.promise(() => Glob.glob(pattern, { cwd }))
       }),
       bash: Effect.fn("AgentTools.bash")(function* (options) {
-        const timeoutMs = options.timeoutMs ?? 120_000
+        const timeoutMs = normalizeBashTimeoutMs(options.timeoutMs)
         yield* Effect.logInfo(`Calling "bash"`).pipe(
           Effect.annotateLogs({
             ...options,


### PR DESCRIPTION
## Summary
- cap `bash` tool execution timeout at 240000ms (4 minutes), even when a larger timeout is requested
- update `bash.timeoutMs` parameter documentation to include the new maximum
- add unit tests for timeout normalization behavior (`src/AgentTools.test.ts`)
- add a changeset (`.changeset/tasty-years-tie.md`)

## Validation
- `pnpm check`
- `pnpm test`