### PR TITLE
TIM-746: limit code chunks by character count

### DIFF
--- a/.changeset/swift-planes-burn.md
+++ b/.changeset/swift-planes-burn.md
@@ -1,0 +1,5 @@
+---
+"clanka": patch
+---
+
+Add character-based chunk size limits to CodeChunker with overlap-preserving splitting, and allow SemanticSearch chunking to configure chunkMaxCharacters (default 30,000).

--- a/src/CodeChunker.test.ts
+++ b/src/CodeChunker.test.ts
@@ -162,6 +162,83 @@ describe("chunkFileContent", () => {
     })
   })
 
+  it("limits AST chunks by character count and drops punctuation-only segments", () => {
+    const content = [
+      "export function demo() {",
+      "  const alpha = 1",
+      "  const beta = 2",
+      "  return alpha + beta",
+      "}",
+    ].join("\n")
+
+    const chunks = chunkFileContent("src/demo.ts", content, {
+      chunkSize: 20,
+      chunkOverlap: 1,
+      chunkMaxCharacters: 21,
+    })
+
+    expect(chunks).toHaveLength(4)
+    expect(chunks).toMatchObject([
+      {
+        startLine: 1,
+        endLine: 1,
+        name: "demo",
+        type: "function",
+        content: "export function demo() {",
+      },
+      {
+        startLine: 2,
+        endLine: 2,
+        name: "demo",
+        type: "function",
+        content: "  const alpha = 1",
+      },
+      {
+        startLine: 3,
+        endLine: 3,
+        name: "demo",
+        type: "function",
+        content: "  const beta = 2",
+      },
+      {
+        startLine: 4,
+        endLine: 4,
+        name: "demo",
+        type: "function",
+        content: "  return alpha + beta",
+      },
+    ])
+  })
+
+  it("limits line-window chunks by character count while preserving overlap", () => {
+    const content = ["aaaaa", "bbbbb", "ccccc", "ddddd"].join("\n")
+
+    const chunks = chunkFileContent("docs/notes.txt", content, {
+      chunkSize: 4,
+      chunkOverlap: 1,
+      chunkMaxCharacters: 11,
+    })
+
+    expect(chunks).toHaveLength(3)
+    expect(chunks).toMatchObject([
+      {
+        startLine: 1,
+        endLine: 2,
+        content: ["aaaaa", "bbbbb"].join("\n"),
+      },
+      {
+        startLine: 2,
+        endLine: 3,
+        content: ["bbbbb", "ccccc"].join("\n"),
+      },
+      {
+        startLine: 3,
+        endLine: 4,
+        content: ["ccccc", "ddddd"].join("\n"),
+      },
+    ])
+  })
+
   it("keeps only the first oversized class segment when methods are present", () => {
     const content = [
       "class Example {",

--- a/src/CodeChunker.ts
+++ b/src/CodeChunker.ts
@@ -59,18 +59,21 @@ export class CodeChunker extends ServiceMap.Service<
       readonly path: string
       readonly chunkSize: number
       readonly chunkOverlap: number
+      readonly chunkMaxCharacters?: number | undefined
     }): Effect.Effect<ReadonlyArray<CodeChunk>>
     chunkFiles(options: {
       readonly root: string
       readonly paths: ReadonlyArray<string>
       readonly chunkSize: number
       readonly chunkOverlap: number
+      readonly chunkMaxCharacters?: number | undefined
     }): Stream.Stream<CodeChunk>
     chunkCodebase(options: {
       readonly root: string
       readonly maxFileSize?: string | undefined
       readonly chunkSize: number
       readonly chunkOverlap: number
+      readonly chunkMaxCharacters?: number | undefined
     }): Stream.Stream<CodeChunk>
   }
 >()("clanka/CodeChunker") {}
@@ -157,6 +160,7 @@ interface LineRange {
 interface ChunkSettings {
   readonly chunkSize: number
   readonly chunkOverlap: number
+  readonly chunkMaxCharacters: number
 }
 
 interface ChunkRange extends LineRange {
@@ -234,16 +238,23 @@ export const isMeaningfulFile = (path: string): boolean => {
 const resolveChunkSettings = (options: {
   readonly chunkSize: number
   readonly chunkOverlap: number
+  readonly chunkMaxCharacters?: number | undefined
 }): ChunkSettings => {
   const chunkSize = Math.max(1, options.chunkSize)
   const chunkOverlap = Math.max(
     0,
     Math.min(chunkSize - 1, options.chunkOverlap),
   )
+  const chunkMaxCharacters =
+    options.chunkMaxCharacters !== undefined &&
+    Number.isFinite(options.chunkMaxCharacters)
+      ? Math.max(1, Math.floor(options.chunkMaxCharacters))
+      : Number.POSITIVE_INFINITY
 
   return {
     chunkSize,
     chunkOverlap,
+    chunkMaxCharacters,
   }
 }
 
@@ -345,24 +356,76 @@ const normalizeLineRange = (
   }
 }
 
+const lineLengthPrefixSums = (
+  lines: ReadonlyArray<string>,
+): ReadonlyArray<number> => {
+  const sums = [0] as Array<number>
+
+  for (let index = 0; index < lines.length; index++) {
+    sums.push(sums[index]! + lines[index]!.length)
+  }
+
+  return sums
+}
+
+const lineRangeCharacterLength = (
+  prefixSums: ReadonlyArray<number>,
+  range: LineRange,
+): number =>
+  prefixSums[range.endLine]! -
+  prefixSums[range.startLine - 1]! +
+  (range.endLine - range.startLine)
+
+const resolveSegmentEndLine = (options: {
+  readonly startLine: number
+  readonly maxEndLine: number
+  readonly settings: ChunkSettings
+  readonly prefixSums: ReadonlyArray<number>
+}): number => {
+  if (options.settings.chunkMaxCharacters === Number.POSITIVE_INFINITY) {
+    return options.maxEndLine
+  }
+
+  let endLine = options.maxEndLine
+  while (
+    endLine > options.startLine &&
+    lineRangeCharacterLength(options.prefixSums, {
+      startLine: options.startLine,
+      endLine,
+    }) > options.settings.chunkMaxCharacters
+  ) {
+    endLine--
+  }
+
+  return endLine
+}
+
 const splitRange = (
   range: LineRange,
   settings: ChunkSettings,
+  prefixSums: ReadonlyArray<number>,
 ): ReadonlyArray<LineRange> => {
   const lineCount = range.endLine - range.startLine + 1
-  if (lineCount <= settings.chunkSize) {
+  if (
+    lineCount <= settings.chunkSize &&
+    lineRangeCharacterLength(prefixSums, range) <= settings.chunkMaxCharacters
+  ) {
     return [range]
   }
-
-  const step = settings.chunkSize - settings.chunkOverlap
   const out = [] as Array<LineRange>
 
-  for (
-    let startLine = range.startLine;
-    startLine <= range.endLine;
-    startLine += step
-  ) {
-    const endLine = Math.min(range.endLine, startLine + settings.chunkSize - 1)
+  for (let startLine = range.startLine; startLine <= range.endLine; ) {
+    const maxEndLine = Math.min(
+      range.endLine,
+      startLine + settings.chunkSize - 1,
+    )
+    const endLine = resolveSegmentEndLine({
+      startLine,
+      maxEndLine,
+      settings,
+      prefixSums,
+    })
+
     out.push({
       startLine,
       endLine,
@@ -371,6 +434,8 @@ const splitRange = (
     if (endLine >= range.endLine) {
       break
     }
+
+    startLine = Math.max(startLine + 1, endLine - settings.chunkOverlap + 1)
   }
 
   return out
@@ -648,6 +713,7 @@ const chunksFromRanges = (
 
   const out = [] as Array<CodeChunk>
   const seen = new Set<string>()
+  const prefixSums = lineLengthPrefixSums(lines)
 
   for (const range of ranges) {
     const normalizedRange = normalizeLineRange(range, lines.length)
@@ -655,7 +721,7 @@ const chunksFromRanges = (
       continue
     }
 
-    const allSegments = splitRange(normalizedRange, settings)
+    const allSegments = splitRange(normalizedRange, settings, prefixSums)
     const segments =
       range.type === "class" &&
       allSegments.length > 1 &&
@@ -709,8 +775,8 @@ const chunkWithLineWindows = (
   lines: ReadonlyArray<string>,
   settings: ChunkSettings,
 ): ReadonlyArray<CodeChunk> => {
-  const step = settings.chunkSize - settings.chunkOverlap
   const out = [] as Array<CodeChunk>
+  const prefixSums = lineLengthPrefixSums(lines)
 
   for (let index = 0; index < lines.length; ) {
     if (!isMeaningfulLine(lines[index]!)) {
@@ -718,25 +784,38 @@ const chunkWithLineWindows = (
       continue
     }
 
-    const start = index
-    const end = Math.min(lines.length, start + settings.chunkSize)
-    const chunkLines = lines.slice(start, end)
+    const startLine = index + 1
+    const maxEndLine = Math.min(
+      lines.length,
+      startLine + settings.chunkSize - 1,
+    )
+    const endLine = resolveSegmentEndLine({
+      startLine,
+      maxEndLine,
+      settings,
+      prefixSums,
+    })
+    const chunkLines = lines.slice(startLine - 1, endLine)
 
     out.push({
       path,
-      startLine: start + 1,
-      endLine: end,
+      startLine,
+      endLine,
       name: undefined,
       type: undefined,
       parent: undefined,
       content: chunkLines.join("\n"),
     })
 
-    index += step
-
-    if (end >= lines.length) {
+    if (endLine >= lines.length) {
       break
     }
+
+    const nextStartLine = Math.max(
+      startLine + 1,
+      endLine - settings.chunkOverlap + 1,
+    )
+    index = nextStartLine - 1
   }
 
   return out
@@ -752,6 +831,7 @@ export const chunkFileContent = (
   options: {
     readonly chunkSize: number
     readonly chunkOverlap: number
+    readonly chunkMaxCharacters?: number | undefined
   },
 ): ReadonlyArray<CodeChunk> => {
   if (content.trim().length === 0 || isProbablyMinified(content)) {
@@ -869,6 +949,9 @@ export const layer: Layer.Layer<
                 path,
                 chunkSize: options.chunkSize,
                 chunkOverlap: options.chunkOverlap,
+                ...(options.chunkMaxCharacters === undefined
+                  ? {}
+                  : { chunkMaxCharacters: options.chunkMaxCharacters }),
               }),
               Stream.fromArrayEffect,
             ),
@@ -891,6 +974,9 @@ export const layer: Layer.Layer<
           paths: files,
           chunkSize: options.chunkSize,
           chunkOverlap: options.chunkOverlap,
+          ...(options.chunkMaxCharacters === undefined
+            ? {}
+            : { chunkMaxCharacters: options.chunkMaxCharacters }),
         })
       }, Stream.unwrap)
 

--- a/src/SemanticSearch.ts
+++ b/src/SemanticSearch.ts
@@ -42,10 +42,13 @@ export class SemanticSearch extends ServiceMap.Service<
 
 const normalizePath = (path: string) => path.replace(/\\/g, "/")
 
-const chunkConfig = {
+const resolveChunkConfig = (options: {
+  readonly chunkMaxCharacters?: number | undefined
+}) => ({
   chunkSize: 30,
   chunkOverlap: 0,
-} as const
+  chunkMaxCharacters: options.chunkMaxCharacters ?? 30_000,
+})
 
 export const makeEmbeddingResolver = (
   resolver: EmbeddingModel.Service["resolver"],
@@ -100,6 +103,7 @@ export const layer = (options: {
   readonly embeddingBatchSize?: number | undefined
   readonly embeddingRequestDelay?: Duration.Input | undefined
   readonly concurrency?: number | undefined
+  readonly chunkMaxCharacters?: number | undefined
 }): Layer.Layer<
   SemanticSearch,
   | SqlError.SqlError
@@ -121,6 +125,7 @@ export const layer = (options: {
       const root = pathService.resolve(options.directory)
       const resolver = makeEmbeddingResolver(embeddings.resolver, options)
       const concurrency = options.concurrency ?? 2000
+      const chunkConfig = resolveChunkConfig(options)
       const indexHandle = yield* FiberHandle.make()
       const console = yield* Console.Console
 


### PR DESCRIPTION
## Summary

- add optional character-based chunk limits to CodeChunker (chunkMaxCharacters) for AST range splitting and fallback line-window splitting
- preserve chunk overlap when character limits shorten a segment by deriving the next start from the emitted end line
- compute chunk character lengths from per-line prefix sums to avoid repeated join/length work while splitting
- add regression tests for AST and line-window chunking under character limits
- update SemanticSearch chunk config resolution so chunkMaxCharacters defaults to 30,000 and can be overridden in layer options
- add changeset: .changeset/swift-planes-burn.md

## Validation

- pnpm check
- pnpm test