### PR TITLE
fix: remove <4.0.1 upper bound on peer deps to prevent pnpm resolving effect 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
     "@sqliteai/sqlite-vector-win32-x86_64": "0.9.95"
   },
   "peerDependencies": {
-    "@effect/ai-openai": ">=4.0.0-beta.52 <4.0.1",
-    "@effect/ai-openai-compat": ">=4.0.0-beta.52 <4.0.1",
-    "@effect/platform-node": ">=4.0.0-beta.52 <4.0.1",
-    "@effect/sql-sqlite-node": ">=4.0.0-beta.52 <4.0.1",
-    "effect": ">=4.0.0-beta.52 <4.0.1"
+    "@effect/ai-openai": ">=4.0.0-beta.52",
+    "@effect/ai-openai-compat": ">=4.0.0-beta.52",
+    "@effect/platform-node": ">=4.0.0-beta.52",
+    "@effect/sql-sqlite-node": ">=4.0.0-beta.52",
+    "effect": ">=4.0.0-beta.52"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",


### PR DESCRIPTION
## Summary

- The `<4.0.1` upper bound on peer dependencies caused `pnpm add -g clanka` to silently resolve `effect@3.19.6` from the local store, since no stable `4.0.0` release exists yet
- `effect@3.19.6` has no `./unstable/cli/Prompt` export, causing the `ERR_PACKAGE_PATH_NOT_EXPORTED` crash on startup
- Removing the upper bound forces pnpm to fetch a `4.x` beta when nothing in the store satisfies `>=4.0.0-beta.52`

## Root cause

pnpm global installs don't auto-install missing peers — they reuse whatever version is already in the content-addressable store. With `<4.0.1` as the upper bound, `effect@3.19.6` satisfied the range (3.x < 4.0.1), so pnpm used it. npm/npx works because it fetches peers fresh in a temp directory.

## Test plan

- [ ] `pnpm remove -g clanka && pnpm add -g clanka` — should no longer crash with `ERR_PACKAGE_PATH_NOT_EXPORTED`
- [ ] `clanka --help` should print usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)


TLDR: whenever I installed clanka with `pnpm` it failed with 

```
node:internal/modules/esm/resolve:313
    return new ERR_PACKAGE_PATH_NOT_EXPORTED(
           ^

  Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './unstable/cli/Prompt' is not defined by "exports" in
```

claude debugged it for me, i installed the build with pnpm locally (removed my install of clanka, installed with the build) and it worked.

